### PR TITLE
Add subtyping experiment

### DIFF
--- a/metta/subtyping/README.md
+++ b/metta/subtyping/README.md
@@ -52,7 +52,7 @@ see `STImplCoer` defined in `rule-base.metta`.
 
 ## Conclusion
 
-From that experiment we can conclude two things.
+From that experiment we can conclude:
 
 1. Subtyping is possible with MeTTa
 2. Explicit coercion allows to treat programs (in that case coercion

--- a/metta/subtyping/README.md
+++ b/metta/subtyping/README.md
@@ -1,27 +1,62 @@
 # Subtyping
 
 Define a [subtyping](https://en.wikipedia.org/wiki/Subtyping)
-relationship `<:`.  That is
+relationship `<:`.
+
+Type `T1` is a subtype of `T2` is denoted as `T1 <: T2` or, in MeTTa
+format
 
 ```
 (<: T1 T2)
 ```
 
-means that type `T1` is a subtype of `T2`.
-
 ## Algebraic Laws
 
-- Reflexive: `(<: T T)`
-- Transitive: If `(<: T1 T2)` and `(<: T2 T3)` then `(<: T1 T3)`
+The subtyping relationship is:
+
+- Reflexive:
+  ```
+  ⊢ T <: T
+  ```
+- Transitive:
+  ```
+  T1 <: T2
+  T2 <: T3
+  ⊢
+  T1 <: T3
+  ```
+- Contravariant over inputs and covariant over outputs:
+  ```
+  T1 <: S1
+  S2 <: T2
+  ⊢
+  S1 -> S2 <: T1 -> T2
+  ```
 
 ## Relationships between Subtyping and Typing
 
-There are two variants of that experiment, one with explicit coercion,
-and one implicit coercion.
+There are two variants of relationship between subtyping and type, one
+using explicit coercion, the other using implicit coercion.
 
 ### Explicit Coercion
 
+For explicit coercion, the inference rule is the coercion function
+itself, see `coerce` defined in `rule-base.metta`.
+
 ### Implicit Coercion
 
-Because MeTTa supports non-determinism, we are also able to use
-implicit type coercion.
+Because MeTTa supports non-determinism we can also do implicit type
+coercion.  In that case the typing relationship is treated itself as
+type, and its witness is an inference rule, not a coercion function,
+see `STImplCoer` defined in `rule-base.metta`.
+
+## Conclusion
+
+From that experiment we can conclude two things.
+
+1. Subtyping is possible with MeTTa
+2. Explicit coercion allows to treat programs (in that case coercion
+   functions) on the same level as proofs, in a Curry-Howard
+   correspondance style.
+3. Implicit coercion has the adventage of not requiring a coercion
+   function, but does not treat functions on the same level as proofs.

--- a/metta/subtyping/README.md
+++ b/metta/subtyping/README.md
@@ -52,11 +52,11 @@ see `STImplCoer` defined in `rule-base.metta`.
 
 ## Conclusion
 
-From that experiment we can conclude:
+From that experiment we can conclude the following:
 
-1. Subtyping is possible with MeTTa
+1. Subtyping is possible with MeTTa.
 2. Explicit coercion allows to treat programs (in that case coercion
    functions) on the same level as proofs, in a Curry-Howard
-   correspondance style.
-3. Implicit coercion has the adventage of not requiring a coercion
+   correspondence fashion.
+3. Implicit coercion has the advantage of not requiring a coercion
    function, but does not treat functions on the same level as proofs.

--- a/metta/subtyping/README.md
+++ b/metta/subtyping/README.md
@@ -1,0 +1,27 @@
+# Subtyping
+
+Define a [subtyping](https://en.wikipedia.org/wiki/Subtyping)
+relationship `<:`.  That is
+
+```
+(<: T1 T2)
+```
+
+means that type `T1` is a subtype of `T2`.
+
+## Algebraic Laws
+
+- Reflexive: `(<: T T)`
+- Transitive: If `(<: T1 T2)` and `(<: T2 T3)` then `(<: T1 T3)`
+
+## Relationships between Subtyping and Typing
+
+There are two variants of that experiment, one with explicit coercion,
+and one implicit coercion.
+
+### Explicit Coercion
+
+### Implicit Coercion
+
+Because MeTTa supports non-determinism, we are also able to use
+implicit type coercion.

--- a/metta/subtyping/rule-base.metta
+++ b/metta/subtyping/rule-base.metta
@@ -1,0 +1,47 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Rule base for the subtyping relationship ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Notations:
+;;
+;; 1. Variables in upper case, like `$T`, tend to correspond to types.
+;; 2. Variables in lower case, like `$t`, tend to correspond to terms.
+;; 3. In the rule names
+;; 3.1. ST stands for SubTyping,
+;; 3.2. Refl for Reflexive,
+;; 3.3. Trans for transitive,
+;; 3.4. FnTy for Function Type,
+;; 3.5. ImplCoer for Implicit Coercion.
+
+;; TODO: maybe we should add (: $T Type) as premises
+
+;; Subtyping is relexive.  WARNING: that one is actually an axiom, not
+;; a rule.
+(: STRefl (<: $T $T))
+
+;; Subtyping is transitive
+(: STTrans (->
+            ;; Premises
+            (<: $S $T)
+            (<: $T $U)
+            ;; Conclusion
+            (<: $S $U)))
+
+;; Subtyping of function types is contravariant over inputs and
+;; covariant over outputs.
+(: STFnTy (->
+           ;; Premises
+           (<: $T1 $S1)
+           (<: $S2 $T2)
+           ;; Conclusion
+           (<: (-> $S1 $S2) (-> $T1 $T2))))
+
+;; Relationship between subtyping and type.  For now we assume
+;; implicit coercion.  That is if a term t is of type S a subtype of
+;; T, then t is of type T as well.
+(: STImplCoer (->
+               ;; Premises
+               (<: $S $T)
+               (: $t $S)
+               ;; Conclusion
+               (: $t $T)))

--- a/metta/subtyping/rule-base.metta
+++ b/metta/subtyping/rule-base.metta
@@ -36,12 +36,23 @@
            ;; Conclusion
            (<: (-> $S1 $S2) (-> $T1 $T2))))
 
-;; Relationship between subtyping and type.  For now we assume
-;; implicit coercion.  That is if a term t is of type S a subtype of
-;; T, then t is of type T as well.
+;; Relationship between subtyping and type assuming implicit coercion.
+;; That is if a term `t` is of type `S` a subtype of `T`, then `t` is
+;; of type `T` as well.
 (: STImplCoer (->
                ;; Premises
                (<: $S $T)
                (: $t $S)
                ;; Conclusion
                (: $t $T)))
+
+;; Relationship between subtyping and type assume explicit coercion.
+;; That is if a term `t` is of type `S` a subtype of `T`, then
+;; `(coerce proof_S<:T t)` is of type `T`, where `proof_S<:T` is a
+;; proof that `S` is a subtype of `T`.
+(: coerce (->
+           ;; Premises
+           (<: $S $T)
+           $S
+           ;; Conclusion
+           $T))

--- a/metta/subtyping/subtyping-test.metta
+++ b/metta/subtyping/subtyping-test.metta
@@ -1,0 +1,43 @@
+;; Test subtyping
+
+;; Import synthesizer
+!(import! &self ../synthesis/Synthesize.metta)
+
+;; Import rule base
+!(import! &rb rule-base.metta)
+
+;; Define knowledge base for that test
+(: kb (-> Atom))
+(= (kb) (superpose ((: STRefl (<: $T $T)) ; WARNING: has to be added here because it is an axiom
+                    (: CM (<: Cat Mammal))
+                    (: MA (<: Mammal Animal))
+                    (: AP (<: Animal Physical))
+                    (: fC (: felix Cat))
+                    (: wPW (: weigh (-> Physical Weight))))))
+
+;; Define rule base (called rb but different than &rb)
+(: rb (-> Atom))
+(= (rb) (match &rb $x $x))
+
+;; Check that felix is a cat
+!(assertEqual
+  (synthesize (: $proof (: felix Cat)) kb rb Z)
+  (: fC (: felix Cat)))
+
+;; Check that felix is a mammal
+!(synthesize (: $proof (: felix Mammal)) kb rb (fromNumber 1))
+
+;; Check that cat is a subtype of animal
+!(synthesize (: $proof (<: Cat Animal)) kb rb (fromNumber 1))
+
+;; Check that felix is an animal
+!(synthesize (: $proof (: felix Animal)) kb rb (fromNumber 2))
+
+;; Check that (-> Physical Weight) is a subtype of (-> Cat Weight)
+!(synthesize (: $proof (<: (-> Physical Weight) (-> Cat Weight))) kb rb (fromNumber 3))
+
+;; Find a function to weigh something physical, and its associated proof
+!(synthesize (: $proof (: $fun (-> Physical Weight))) kb rb (fromNumber 0))
+
+;; Find a function to weigh a cat, and its associated proof
+!(synthesize (: $proof (: $fun (-> Cat Weight))) kb rb (fromNumber 3))

--- a/metta/subtyping/subtyping-test.metta
+++ b/metta/subtyping/subtyping-test.metta
@@ -8,10 +8,16 @@
 
 ;; Define knowledge base for that test
 (: kb (-> Atom))
-(= (kb) (superpose ((: STRefl (<: $T $T)) ; WARNING: has to be added here because it is an axiom
+(= (kb) (superpose (;; Reflexivity axiom
+                    (: STRefl (<: $T $T))
+                    ;; Subtype relationships
                     (: CM (<: Cat Mammal))
                     (: MA (<: Mammal Animal))
                     (: AP (<: Animal Physical))
+                    ;; Explicit coercion
+                    (: felix Cat)
+                    (: weigh (-> Physical Weight))
+                    ;; Implicit coercion
                     (: fC (: felix Cat))
                     (: wPW (: weigh (-> Physical Weight))))))
 
@@ -24,20 +30,34 @@
   (synthesize (: $proof (: felix Cat)) kb rb Z)
   (: fC (: felix Cat)))
 
-;; Check that felix is a mammal
+;; Check that felix is a mammal (explicit coercion)
+!(synthesize (: (coerce $proof felix) Mammal) kb rb (fromNumber 1))
+
+;; Check that felix is a mammal (implicit coercion)
 !(synthesize (: $proof (: felix Mammal)) kb rb (fromNumber 1))
 
 ;; Check that cat is a subtype of animal
 !(synthesize (: $proof (<: Cat Animal)) kb rb (fromNumber 1))
 
-;; Check that felix is an animal
+;; Check that felix is an animal (explicit coercion)
+!(synthesize (: (coerce $proof felix) Animal) kb rb (fromNumber 2))
+
+;; Check that felix is an animal (implicit coercion)
 !(synthesize (: $proof (: felix Animal)) kb rb (fromNumber 2))
 
 ;; Check that (-> Physical Weight) is a subtype of (-> Cat Weight)
 !(synthesize (: $proof (<: (-> Physical Weight) (-> Cat Weight))) kb rb (fromNumber 3))
 
-;; Find a function to weigh something physical, and its associated proof
+;; Find a function to weigh something physical (explicit coercion).
+!(synthesize (: $fun (-> Physical Weight)) kb rb (fromNumber 0))
+
+;; Find a function to weigh something physical and its associated
+;; proof (implicit coercion).
 !(synthesize (: $proof (: $fun (-> Physical Weight))) kb rb (fromNumber 0))
 
-;; Find a function to weigh a cat, and its associated proof
+;; Find a function to weigh a cat (explicit coercion).
+!(synthesize (: $fun (-> Cat Weight)) kb rb (fromNumber 3))
+
+;; Find a function to weigh a cat and its associated proof (implicit
+;; coercion).
 !(synthesize (: $proof (: $fun (-> Cat Weight))) kb rb (fromNumber 3))


### PR DESCRIPTION
From that experiment we can conclude the following:
1. Subtyping is possible with MeTTa.
2. Explicit coercion allows to treat programs (in that case coercion
   functions) on the same level as proofs, in a Curry-Howard
   correspondence fashion.
3. Implicit coercion has the advantage of not requiring a coercion
   function, but does not treat functions on the same level as proofs.
