### PR TITLE
Number of experiments with forward chaining

### DIFF
--- a/metta/README.md
+++ b/metta/README.md
@@ -9,3 +9,4 @@ organized into the following folders:
 - dependent-types: rule is represented as type constructor;
 - common: definitions common to some or all ways.
 - synthesis: program synthesis experiments.
+- forward-chainer: forward chainer experiments.

--- a/metta/common/formula/DeductionFormula.metta
+++ b/metta/common/formula/DeductionFormula.metta
@@ -35,26 +35,6 @@
      ;; Preconditions are not met
      0))
 
-;; Deduction formula
-(= (ded_formula $ptv $qtv $rtv $pqtv $qrtv)
-    (let*
-        (($Pc (confidence $ptv))
-         ($Qc (confidence $qtv))
-         ($Rc (confidence $rtv))
-         ($PQc (confidence $pqtv))
-         ($QRc (confidence $qrtv))
-         ($PQs (mode $pqtv))
-         ($QRs (mode $qrtv))
-         ($Ps (mode $ptv))
-         ($Qs (mode $qtv))
-         ($Rs (mode $rtv)))
-        (let*
-            (($PRs (simple-deduction-strength-formula $Ps $Qs $Rs $PQs $QRs))
-             ($PRc (min $Pc (min $Qc (min $Rc (min $PQc $QRc))))))
-            (if (== $PRs 0)
-                (PrCnt 1 0)
-                (PrCnt $PRs $PRs)))))
-
 ;; Alternate deduction formula hardwired for STV to make it faster.
 (= (deduction-formula (STV $Ps $Pc)
                       (STV $Qs $Qc)

--- a/metta/common/formula/DeductionFormula.metta
+++ b/metta/common/formula/DeductionFormula.metta
@@ -15,10 +15,9 @@
 
 (: conditional-probability-consistency (-> Number Number Number Bool))
 (= (conditional-probability-consistency $As $Bs $ABs)
-   True)
-   ;; (and (< 0 $As)
-   ;;      (and (<= (smallest-intersection-probability $As $Bs) $ABs)
-   ;;           (<= $ABs (largest-intersection-probability $As $Bs)))))
+   (and (< 0 $As)
+        (and (<= (smallest-intersection-probability $As $Bs) $ABs)
+             (<= $ABs (largest-intersection-probability $As $Bs)))))
 
 ;; Main Formula
 (: simple-deduction-strength-formula (-> Number Number Number Number Number Number))

--- a/metta/common/formula/DeductionFormulaTest.metta
+++ b/metta/common/formula/DeductionFormulaTest.metta
@@ -11,7 +11,6 @@
 !(smallest-intersection-probability 0.9 0.6)
 !(conditional-probability-consistency 0.9 0.6 0.5)
 !(simple-deduction-strength-formula 0.9 0.6 0.5 0.3 0.4)
-!(ded_formula (PrCnt 1 10) (PrCnt 1 4) (PrCnt 1 2) (PrCnt 1 3) (PrCnt 1 5))
 !(conditional-probability-consistency 0.2 0.3 1)
 !(conditional-probability-consistency 0.3 0.4 0.9)
 !(deduction-formula (STV 0.2 0.3) (STV 0.3 0.2) (STV 0.4 0.1) (STV 1 0.5) (STV 0.9 0.7))

--- a/metta/common/formula/ImplicationDirectIntroductionFormula.metta
+++ b/metta/common/formula/ImplicationDirectIntroductionFormula.metta
@@ -5,17 +5,15 @@
 
 ;; Alternate implication direct introduction formula assuming Boolean
 ;; evidence.  Base case, meaning there is only one piece of evidence.
-(: direct-introduction-base-formula (-> Bool Bool TruthValue))
-(= (direct-introduction-base-formula False $_) (STV 1 0))
-(= (direct-introduction-base-formula True $qa)
+(: direct-introduction-base-formula (-> Bool TruthValue))
+(= (direct-introduction-base-formula $qa)
    (STV (bool->number $qa) (count->confidence 1)))
 
 ;; Alternate implication direct introduction formula.  Inductive case,
 ;; meaning the piece of evidence gets aggregated to another truth
 ;; value.
-(: direct-introduction-recursive-formula (-> Bool Bool TruthValue TruthValue))
-(= (direct-introduction-recursive-formula False $_ (STV $PQs $PQc)) (STV $PQs $PQc))
-(= (direct-introduction-recursive-formula True False (STV $PQs $PQc))
-   (STV (inc-count-strength $PQs $PQc) (inc-confidence $PQc)))
-(= (direct-introduction-recursive-formula True True (STV $PQs $PQc))
-   (STV $PQs (inc-confidence $PQc)))
+(: direct-introduction-recursive-formula (-> Bool TruthValue TruthValue))
+(= (direct-introduction-recursive-formula False (STV $PQs $PQc))
+   (inc-neg-count (STV $PQs $PQc)))
+(= (direct-introduction-recursive-formula True (STV $PQs $PQc))
+   (inc-pos-count (STV $PQs $PQc)))

--- a/metta/common/truthvalue/TruthValue.metta
+++ b/metta/common/truthvalue/TruthValue.metta
@@ -31,10 +31,10 @@
 
 ;; For now the underlying beta distributions have a Jeffreys prior,
 ;; i.e. the prior alpha and beta are 0.5.
-(: prior_alpha (-> Number))
-(= (prior_alpha) 0.5)
-(: prior_beta (-> Number))
-(= (prior_beta) 0.5)
+(: prior-alpha (-> Number))
+(= (prior-alpha) 0.5)
+(: prior-beta (-> Number))
+(= (prior-beta) 0.5)
 
 ;; Lookahead
 (: lookahead (-> Number))
@@ -115,20 +115,20 @@
 (= (confidence (STV $_ $conf)) $conf)
 
 ;; Return the positive count of a truth value.
-(: pos_count (-> TruthValue Number))
-(= (pos_count $tv) (* (mode $tv) (count $tv)))
+(: pos-count (-> TruthValue Number))
+(= (pos-count $tv) (* (mode $tv) (count $tv)))
 
 ;; Return the negative count of a truth value.
-(: neg_count (-> TruthValue Number))
-(= (neg_count $tv) (* (- 1 (mode $tv)) (count $tv)))
+(: neg-count (-> TruthValue Number))
+(= (neg-count $tv) (* (- 1 (mode $tv)) (count $tv)))
 
 ;; Return the posterior alpha of a truth value
-(: post_alpha (-> TruthValue Number))
-(= (post_alpha $tv) (+ (prior_alpha) (pos_count $tv)))
+(: post-alpha (-> TruthValue Number))
+(= (post-alpha $tv) (+ (prior-alpha) (pos-count $tv)))
 
 ;; Return the posterior beta of a truth value
-(: post_beta (-> TruthValue Number))
-(= (post_beta $tv) (+ (prior_beta) (neg_count $tv)))
+(: post-beta (-> TruthValue Number))
+(= (post-beta $tv) (+ (prior-beta) (neg-count $tv)))
 
 ;; Return the first order probability mean of the second order
 ;; distribution associated to a truth value.  For truth values not

--- a/metta/common/truthvalue/TruthValue.metta
+++ b/metta/common/truthvalue/TruthValue.metta
@@ -20,12 +20,6 @@
 ;; First order probability TV constructor, i.e. mere probability.
 (: Pr (-> Number TruthValue))
 
-;; Second order probability TV constructor, i.e. probability and
-;; count.  The second order probability is distributed according to a
-;; beta distribution.  The first argument of the constructor
-;; represents the mode of the second order distribution.
-(: PrCnt (-> Number Number TruthValue))
-
 ;; Simple Truth Value.  A Second order probability TV constructor,
 ;; i.e. probability and confidence.  The probability is in fact the
 ;; mode of the corresponding beta distribution.
@@ -97,32 +91,27 @@
 (= (mode (Bl True)) 1.0)
 (= (mode (Bl False)) 0.0)
 (= (mode (Pr $pr)) $pr)
-(= (mode (PrCnt $pr $_)) $pr)
 (= (mode (STV $pr $_)) $pr)
 
 ;; Return the total count of a truth value.  For truth values not
 ;; capturing a notion of confidence, such as Bl or Pr then the count
 ;; is assumed to be a very large number (cause +inf does not seem to
-;; be supported at the moment).  For truth values capturing a notion
-;; of confidence, such as PrCnt, the total count is the count
-;; component of the truth value.
+;; be supported at the moment).
 (: count (-> TruthValue Number))
 (= (count (Bl $_)) (max-count))
 (= (count (Pr $_)) (max-count))
-(= (count (PrCnt $_ $cnt)) $cnt)
 (= (count (STV $_ $conf)) (confidence->count $conf))
 
 ;; Return the confidence of a truth value.  For truth values not
 ;; capturing a notion of confidence, such as Bl or Pr then the
 ;; confidence is assumed to be 1.0.  For truth values capturing a
-;; notion of confidence, such as PrCnt, the formula to convert a count
+;; notion of confidence, such as STV, the formula to convert a count
 ;; into confidence is as follows
 ;;
 ;; confidence = count / (count + lookahead)
 (: confidence (-> TruthValue Number))
 (= (confidence (Bl $_)) 1.0)
 (= (confidence (Pr $_)) 1.0)
-(= (confidence (PrCnt $_ $cnt)) (count->confidence $cnt))
 (= (confidence (STV $_ $conf)) $conf)
 
 ;; Return the positive count of a truth value.
@@ -145,16 +134,11 @@
 ;; distribution associated to a truth value.  For truth values not
 ;; capturing a notion of confidence, such as Bl or Pr then the
 ;; confidence is assumed to be 1.0.  For truth values capturing a
-;; notion of confidence, such as PrCnt, a beta distribution is
-;; assumed.
+;; notion of confidence, such as STV, a beta distribution is assumed.
 (: mean (-> TruthValue Number))
 (= (mean (Bl True)) 1.0)
 (= (mean (Bl False)) 0.0)
 (= (mean (Pr $pr)) $pr)
-(= (mean (PrCnt $pr $cnt))
-   (let* (($a (post_alpha (PrCnt $pr $cnt)))
-          ($b (post_beta (PrCnt $pr $cnt))))
-     (/ $a (+ $a $b))))
 (= (mean (STV $pr $conf))
    (let* (($a (post_alpha (STV $pr $conf)))
           ($b (post_beta (STV $pr $conf))))

--- a/metta/common/truthvalue/TruthValue.metta
+++ b/metta/common/truthvalue/TruthValue.metta
@@ -62,28 +62,25 @@
                                  (max-count)
                                  (/ (* $conf (lookahead)) (- 1.0 $conf))))
 
-;; Increment the given count by 1
-(: inc-count (-> Number Number))
-(= (inc-count $cnt) (+ 1 $cnt))
+;; Increment the negative count of a given truth value, by
+;; incrementing its total count without incrementing the positive
+;; count.
+(: inc-neg-count (-> TruthValue TruthValue))
+(= (inc-neg-count (STV $s $c)) (let* (($tot_cnt (confidence->count $c))
+                                      ($pos_cnt (* $s $tot_cnt))
+                                      ($new_tot_cnt (+ $tot_cnt 1)))
+                                 (STV (/ $pos_cnt $new_tot_cnt)
+                                      (count->confidence $new_tot_cnt))))
 
-;; Increment the corresponding count of the given confidence by 1 and
-;; return the confidence of that corresponding incremented count.
-(: inc-confidence (-> Number Number))
-(= (inc-confidence $conf) (count->confidence (inc-count (confidence->count $conf))))
-
-;; Return the strength of a truth value, given that its count has been
-;; incremented by one but its positive count has not.
-;;
-;; The formula is derived from new_s = s*cnt / (cnt + 1), where cnt is
-;; the count of the original truth value, that is cnt = c*k / (1-c).
-;; Thus
-;;
-;; new_s = (s*c*k / (1-c)) / (c*k / (1-c) + 1)
-;;       = (s*c*k / (1-c)) / ((c*k + 1-c) / (1-c))
-;;       = (s*c*k) / (c*k + 1-c)
-(: inc-count-strength (-> Number Number Number))
-(= (inc-count-strength $s $c)
-   (/ (* $s (* $c (lookahead))) (- (+ (* $c (lookahead)) 1) $c)))
+;; Increment the positive count of a given truth value, by
+;; incrementing its total count and its positive count.
+(: inc-pos-count (-> TruthValue TruthValue))
+(= (inc-pos-count (STV $s $c)) (let* (($tot_cnt (confidence->count $c))
+                                      ($pos_cnt (* $s $tot_cnt))
+                                      ($new_pos_cnt (+ $pos_cnt 1))
+                                      ($new_tot_cnt (+ $tot_cnt 1)))
+                                 (STV (/ $new_pos_cnt $new_tot_cnt)
+                                      (count->confidence $new_tot_cnt))))
 
 ;; Return the first order probability mode of the second order
 ;; distribution associated to a truth value.
@@ -140,6 +137,6 @@
 (= (mean (Bl False)) 0.0)
 (= (mean (Pr $pr)) $pr)
 (= (mean (STV $pr $conf))
-   (let* (($a (post_alpha (STV $pr $conf)))
-          ($b (post_beta (STV $pr $conf))))
+   (let* (($a (post-alpha (STV $pr $conf)))
+          ($b (post-beta (STV $pr $conf))))
      (/ $a (+ $a $b))))

--- a/metta/common/truthvalue/TruthValueTest.metta
+++ b/metta/common/truthvalue/TruthValueTest.metta
@@ -1,9 +1,12 @@
 ;; Import TruthValue
 !(import! &self TruthValue.metta)
 
-!(count->confidence 10)                 ; 0.9090909090909091
-!(confidence->count 0.9)                ; 9.000000000000002
-!(mode (STV 0.1 0.2))                   ; 0.1
-!(mean (STV 0.1 0.9))                   ; 0.14
-!(confidence (STV 0.1 0.2))             ; 0.2
-!(count (STV 0.1 0.9))                  ; 9.000000000000002
+!(assertEqual (count->confidence 1) 0.5)
+!(assertEqual (count->confidence 10) 0.9090909090909091)
+!(assertEqual (confidence->count 0.9) 9.000000000000002)
+!(assertEqual (mode (STV 0.1 0.2)) 0.1)
+!(assertEqual (mean (STV 0.1 0.9)) 0.14)
+!(assertEqual (confidence (STV 0.1 0.2)) 0.2)
+!(assertEqual (count (STV 0.1 0.9)) 9.000000000000002)
+!(assertEqual (inc-neg-count (STV 1 0)) (STV 0 0.5))
+!(assertEqual (inc-pos-count (STV 1 0)) (STV 1 0.5))

--- a/metta/dependent-types/DeductionDTLTest.metta
+++ b/metta/dependent-types/DeductionDTLTest.metta
@@ -44,9 +44,10 @@
 
 ;; Test synthesizer
 ! "===== Test synthesizer ===="
-!(record synthesize ((: $proof (≞ (→ P Q) $tv)) kb rb Z)) ; (: PQm (≞ (→ P Q) (STV 0.8 0.4)))
-!(record synthesize ((: $proof (≞ (→ Q R) $tv)) kb rb Z)) ; (: QRm (≞ (→ Q R) (STV 0.9 0.5)))
-!(record synthesize ((: $proof (≞ (→ P R) $tv)) kb rb (S Z))) ; (: (Deduction Pm Qm Rm PQm QRm) (≞ (→ P R) (STV 0.8 0.1)))
+!(assertEqual (synthesize (: $proof (≞ (→ P Q) $tv)) kb rb Z) (: PQm (≞ (→ P Q) (STV 0.8 0.4))))
+!(assertEqual (synthesize (: $proof (≞ (→ Q R) $tv)) kb rb Z) (: QRm (≞ (→ Q R) (STV 0.9 0.5))))
+;; Do not use assert because of all the incompleted reductions
+!(synthesize (: $proof (≞ (→ P R) $tv)) kb rb (S Z)) ; (: (Deduction Pm Qm Rm PQm QRm) (≞ (→ P R) (STV 0.8 0.1))))
 
 ;; ;; TODO: fix the following
 ;; !(record synthesize ((: $proof (≞ (→ P R) (STV $s $c))) kb rb (S Z))) ; (: (Deduction Pm Qm Rm PQm QRm) (≞ (→ P R) (STV 0.8 0.1)))

--- a/metta/dependent-types/DeductionImplicationDirectIntroductionDTLTest.metta
+++ b/metta/dependent-types/DeductionImplicationDirectIntroductionDTLTest.metta
@@ -69,6 +69,6 @@
 ;; (: (Deduction Pm Qm Rm (EvidenceElimination (IDIBase P2 Q2)) QRm) (≞ (→ P R) (STV 0.18571428571428572 0.1)))
 ;; (: (Deduction Pm Qm Rm (EvidenceElimination (IDIBase P7 Q7)) QRm) (≞ (→ P R) (STV 0.9 0.1)))
 
-;; TODO: disabled because it takes to long for now
+;; Disabled because it takes to long (over an hour)
 ;; ! "===== Prove that P→R based on two pieces of evidence and deduction ====="
 ;; !(synthesize (: (Deduction Pm Qm Rm $PQ QRm) (≞ (→ P R) $etv)) kb rb (fromNumber 5))

--- a/metta/dependent-types/ImplicationDirectIntroductionDTL.metta
+++ b/metta/dependent-types/ImplicationDirectIntroductionDTL.metta
@@ -36,7 +36,7 @@
 ;; (: Deduction
 ;;    (-> (≞ (→ $P $Q) $TV1)
 ;;        (≞ (→ $Q $R) $TV2)
-;;        (≞ (→ $P $R) (ded_formula $TV1 $TV2))))
+;;        (≞ (→ $P $R) (deduction-formula $TV1 $TV2))))
 ;;
 ;; where ≞, → are dependent types, and formula is just a regular metta
 ;; function.
@@ -57,13 +57,15 @@
 
 ;; Base case (one piece of evidence):
 ;;
-;; (p a) = pa
+;; (p a) = True
 ;; (q a) = qa
 ;; ⊢
 ;; p→q ≞ (ETV (:: a ∅) tv)
 ;;
 ;; where tv is calculated according to the direct introduction
-;; formula.
+;; formula.  Note that we don't bother to take into account pieces of
+;; evidence that is not True on (p a), because it has no impact on the
+;; resulting truth value otherwise.
 ;;
 ;; To avoid prematurely reducing (p a) = pa to pa = pa, the following
 ;; representation is used instead
@@ -78,22 +80,25 @@
 (: implication-direct-introduction-base-rule (-> Atom))
 (= (implication-direct-introduction-base-rule)
    (: IDIBase
-      (-> (⊷ $p $a $pa)
+      (-> (⊷ $p $a True)
           (⊷ $q $a $qa)
           (≞ (→ $p $q)
              (ETV (:: $a ∅)
-                  (direct-introduction-base-formula $pa $qa))))))
+                  (direct-introduction-base-formula $qa))))))
 
 ;; Recursive case (more than one piece of evidence):
 ;;
-;; (p a) = pa
+;; (p a) = True
 ;; (q a) = qa
 ;; p→q ≞ (ETV (:: h t) pqtv)
 ;; h < a
 ;; ⊢
 ;; p→q ≞ (ETV (:: a (:: h t)) tv)
 ;;
-;; where tv is calculated using the direct introduction formula.
+;; where tv is calculated using the direct introduction formula.  Note
+;; that we don't bother to take into account pieces of evidence that
+;; is not True on (p a), because it has no impact on the resulting
+;; truth value otherwise.
 ;;
 ;; To avoid prematurely reducing (p a) = pa to pa = pa, the following
 ;; representation is used instead
@@ -130,13 +135,13 @@
 (: implication-direct-introduction-recursive-rule (-> Atom))
 (= (implication-direct-introduction-recursive-rule)
    (: IDIRecursive
-      (-> (⊷ $p $a $pa)
+      (-> (⊷ $p $a True)
           (⊷ $q $a $qa)
           (≞ (→ $p $q) (ETV (:: $h $t) $pqtv))
           (⍃ $h $a)
           (≞ (→ $p $q)
              (ETV (:: $a (:: $h $t))
-                  (direct-introduction-recursive-formula $pa $qa $pqtv))))))
+                  (direct-introduction-recursive-formula $qa $pqtv))))))
 
 ;; Convert an EvidenceTruthValue to a TruthValue (i.e. elimate the
 ;; evidential part).

--- a/metta/dependent-types/ImplicationDirectIntroductionDTLTest.metta
+++ b/metta/dependent-types/ImplicationDirectIntroductionDTLTest.metta
@@ -8,6 +8,10 @@
 (: kb (-> Atom))
 (= (kb) (superpose ((: P2 (⊷ P (fromNumber 2) True))
                     (: Q2 (⊷ Q (fromNumber 2) False))
+                    (: P3 (⊷ P (fromNumber 3) True))
+                    (: Q3 (⊷ Q (fromNumber 3) True))
+                    (: P5 (⊷ P (fromNumber 5) False))
+                    (: Q5 (⊷ Q (fromNumber 5) True))
                     (: P7 (⊷ P (fromNumber 7) True))
                     (: Q7 (⊷ Q (fromNumber 7) True)))))
 ;; Axioms are placed in the kb as well
@@ -62,8 +66,46 @@
 ! "===== Prove that 2 < 7 (synthesizer) ====="
 !(synthesize (: $proof (⍃ (fromNumber 2) (fromNumber 7))) kb rb (fromNumber 2))
 
+! "===== Prove that 2 < 3 (synthesizer) ====="
+!(synthesize (: $proof (⍃ (fromNumber 2) (fromNumber 3))) kb rb (fromNumber 2))
+
+! "===== Prove that 5 < 7 (synthesizer) ====="
+!(synthesize (: $proof (⍃ (fromNumber 3) (fromNumber 7))) kb rb (fromNumber 3))
+
+;; Prove that P→Q using only base rule with only one piece of evidence
 ! "===== Prove P→Q using base rule (synthesizer) ====="
 !(synthesize (: $proof (≞ (→ P Q) $etv)) kb rb (fromNumber 1))
 
+;; Prove that P→Q using one, two and three pieces of evidence.
+;;
+;; The synthesizer should build proof trees using one, two and
+;; ultimate three pieces of evidence.  The proof tree using three
+;; pieces of evidences is displayed below:
+;;
+;;                                                                                                ----(ZeroLTSucc)        ----(ZeroLTSucc)
+;;                                                                                                0 ⍃ 1                   0 ⍃ 4
+;;                                                            --------(P2)     --------(Q2)       ----(SuccMonotonicity)  ----(SuccMonotonicity)
+;;                                                            (P 2) = ⊤        (Q 2) = ⊥          1 ⍃ 2                   1 ⍃ 5
+;;                             --------(P3)     --------(Q3)  -------------------------(IDIBase)  ----(SuccMonotonicity)  ----(SuccMonotonicity)
+;;                             (P 3) = ⊤        (Q 3) = ⊥     P → Q ≞ (:: 2 ∅), <0 0.5>)          2 ⍃ 3                   2 ⍃ 6
+;; --------(P7)  --------(Q7)  -----------------------------------------------------------------------(IDIRecursive)      ----(SuccMonotonicity)
+;; (P 7) = ⊤     (Q 7) = ⊤              P → Q ≞ ((:: 3 (:: 2 ∅)), <0.5 0.6666666666666666>)                                       3 ⍃ 7
+;; ---------------------------------------------------------------------------------------------------------------------------(IDIRecursive)
+;;                                  P → Q ≞ ((:: 7 (:: 5 (:: 2 ∅))), <0.6666666666666666 0.75>)
+;;
+;; Or, in MeTTa format
+;;
+;; (: (IDIRecursive
+;;      P7
+;;      Q7
+;;      (IDIRecursive
+;;        P3
+;;        Q3
+;;        (IDIBase P2 Q2)
+;;        (SuccMonotonicity (SuccMonotonicity ZeroLTSucc)))
+;;      (SuccMonotonicity (SuccMonotonicity (SuccMonotonicity ZeroLTSucc))))
+;;    (≞ (→ P Q)
+;;       (ETV (:: (S (S (S (S (S (S (S Z))))))) (:: (S (S (S Z))) (:: (S (S Z)) ∅)))
+;;            (STV 0.6666666666666666 0.75))))
 ! "===== Prove P→Q using base, recursive and order rules (synthesizer) ====="
-!(synthesize (: $proof (≞ (→ P Q) $etv)) kb rb (fromNumber 3))
+!(synthesize (: $proof (≞ (→ P Q) $etv)) kb rb (fromNumber 4))

--- a/metta/entail/DeductionEntail.metta
+++ b/metta/entail/DeductionEntail.metta
@@ -27,4 +27,4 @@
    (≞ (→ $P $Q) $pqtv)
    (≞ (→ $Q $R) $qrtv)
    ;; conclusion
-   (≞ (→ $P $R) (ded_formula $ptv $qtv $rtv $pqtv $qrtv)))
+   (≞ (→ $P $R) (deduction-formula $ptv $qtv $rtv $pqtv $qrtv)))

--- a/metta/entail/DeductionEntailTest.metta
+++ b/metta/entail/DeductionEntailTest.metta
@@ -1,11 +1,11 @@
 ;; Test Deduction Entail Rule
 !(import! &self DeductionEntail.metta)
 
-(= (P) (≞ P (PrCnt 1 0.1)))
-(= (Q) (≞ Q (PrCnt 1 0.1)))
-(= (R) (≞ R (PrCnt 1 0.1)))
-(= (PQ) (≞ (→ P Q) (PrCnt 1 0.5)))
-(= (QR) (≞ (→ Q R) (PrCnt 1 0.5)))
+(= (P) (≞ P (STV 1 0.1)))
+(= (Q) (≞ Q (STV 1 0.1)))
+(= (R) (≞ R (STV 1 0.1)))
+(= (PQ) (≞ (→ P Q) (STV 1 0.5)))
+(= (QR) (≞ (→ Q R) (STV 1 0.5)))
 
 ;; Forward chain
 !(let* (($p (P))

--- a/metta/entail/ImplicationDirectIntroductionEntail.metta
+++ b/metta/entail/ImplicationDirectIntroductionEntail.metta
@@ -27,8 +27,8 @@
 
 ;; Base case (axiomatic rule):
 ;;
-;; ⊢ p→q ≞ (ETV Empty (PrCnt 1 0))
-(⊢ (≞ (→ $p $q) (ETV Empty (PrCnt 1 0))))
+;; ⊢ p→q ≞ (ETV Empty (STV 1 0))
+(⊢ (≞ (→ $p $q) (ETV Empty (STV 1 0))))
 
 ;; Recursive case (inductive rule):
 ;;

--- a/metta/entail/ImplicationDirectIntroductionEntailTest.metta
+++ b/metta/entail/ImplicationDirectIntroductionEntailTest.metta
@@ -3,7 +3,7 @@
 
 ;; Test formula
 !("========== Test formula ==========")
-!(idi_formula (Bl True) (Bl False) (PrCnt 1 0))
+!(idi_formula (Bl True) (Bl False) (STV 1 0))
 
 ;; Test axiom
 !("========== Test axiom ==========")
@@ -13,7 +13,7 @@
 !("========== Test inductive rule ==========")
 !(let* (($pa (≞ (P 42) (Bl True)))
         ($qa (≞ (Q 42) (Bl False)))
-        ($pq (≞ (→ P Q) (ETV Empty (PrCnt 1 0))))
+        ($pq (≞ (→ P Q) (ETV Empty (STV 1 0))))
         ($an (∉ 42 Empty)))
    (match &self (⊢ $pa $qa $pq $an $conclusion) $conclusion))
 

--- a/metta/equal/DeductionEqual.metta
+++ b/metta/equal/DeductionEqual.metta
@@ -26,13 +26,13 @@
       (≞ $r $rtv)
       (≞ (→ $p $q) $pqtv)
       (≞ (→ $q $r) $qrtv))
-    (≞ (→ $p $r) (ded_formula ($ptv $qtv $rtv $pqtv $qrtv))))
+    (≞ (→ $p $r) (deduction-formula ($ptv $qtv $rtv $pqtv $qrtv))))
 
 ;; Backward
 ;; Unfortunately this won't work, the interpreter cannot unify the left hand side of
 ;; the equality because it contains function calls, as opposed to just constructors.
 
-(= (≞ (→ $p $r) (ded_formula $ptv $qtv $rtv $pqtv $qrtv))
+(= (≞ (→ $p $r) (deduction-formula $ptv $qtv $rtv $pqtv $qrtv))
    (, (≞ $p $ptv)
       (≞ $q $qtv)
       (≞ $r $rtv)

--- a/metta/equal/DeductionEqualTest.metta
+++ b/metta/equal/DeductionEqualTest.metta
@@ -2,23 +2,23 @@
 !(import! &self DeductionEqual.metta)
 
 ;; Test 1:
-!(, (≞ P (PrCnt 1 0.1))
-    (≞ Q (PrCnt 1 0.1))
-    (≞ R (PrCnt 1 0.1))
-    (≞ (→ P Q) (PrCnt 1 0.5))
-    (≞ (→ Q R) (PrCnt 1 0.5)))
+!(, (≞ P (STV 1 0.1))
+    (≞ Q (STV 1 0.1))
+    (≞ R (STV 1 0.1))
+    (≞ (→ P Q) (STV 1 0.5))
+    (≞ (→ Q R) (STV 1 0.5)))
 
 ;; Test 2: Apply deduction rule over the result
 ;; we get from test 1 as an input.
 !(let $PR
-    (,  (≞ P (PrCnt 1 0.1))
-        (≞ Q (PrCnt 1 0.1))
-        (≞ R (PrCnt 1 0.1))
-        (≞ (→ P Q) (PrCnt 1 0.5))
-        (≞ (→ Q R) (PrCnt 1 0.5)))
+    (,  (≞ P (STV 1 0.1))
+        (≞ Q (STV 1 0.1))
+        (≞ R (STV 1 0.1))
+        (≞ (→ P Q) (STV 1 0.5))
+        (≞ (→ Q R) (STV 1 0.5)))
     (,
-    (≞ P (PrCnt 1 0.1))
-    (≞ R (PrCnt 1 0.1))
-    (≞ S (PrCnt 1 0.1))
+    (≞ P (STV 1 0.1))
+    (≞ R (STV 1 0.1))
+    (≞ S (STV 1 0.1))
     $PR
-    (≞ (→ R S) (PrCnt 1 0.5))))
+    (≞ (→ R S) (STV 1 0.5))))

--- a/metta/equal/ImplicationDirectIntroductionEqual.metta
+++ b/metta/equal/ImplicationDirectIntroductionEqual.metta
@@ -28,10 +28,10 @@
 
 ;; Base case (axiomatic rule):
 ;;
-;; p→q ≞ (ETV Empty (PrCnt 1 0))
+;; p→q ≞ (ETV Empty (STV 1 0))
 ;;
 ;; Directly present in the atomspace.
-(≞ (→ $p $q) (ETV Empty (PrCnt 1 0)))
+(≞ (→ $p $q) (ETV Empty (STV 1 0)))
 
 ;; TODO: see MeTTa examples such as b2_backchain.metta,
 ;; b3_direct.metta, b4_nonterm.metta, c3_pln_stv.metta,

--- a/metta/forward-chainer/README.md
+++ b/metta/forward-chainer/README.md
@@ -1,0 +1,31 @@
+# Forward Chainer Experiments
+
+## Description
+
+Contains a number of experiments to realize forward chainer in MeTTa.
+Specifically:
+
+* *Entail*: represent knowledge and rules with the `⊢` relationship.
+* *Bare Entail*: like entail but only rules are represented with the
+  `⊢` relationship.
+* *Equality*: like bare entail but the rules are directly encoded in
+  the forward chainer function.
+* *Bare Entail Match*: like bare entail but both knowledge and rule
+  bases are stored in their own spaces and `match` is used instead of
+  `let`.
+* *Equality Match*: like equality but the knowledge base is stored in
+  its own space, the rules are directly encoded in the forward chainer
+  function, and `match` is used instead of `let`.
+* *DTL*: the knowledge and rule bases are represented with the typing
+  relationship, proofs are carried along the chaining, as in a
+  Dependently Typed Language.
+
+## Usage
+
+To run the experiments, enter the following
+
+```bash
+metta forward-chainer-test.metta
+```
+
+It should outputs empty results indicating that all tests have passed.

--- a/metta/forward-chainer/forward-chainer-test.metta
+++ b/metta/forward-chainer/forward-chainer-test.metta
@@ -120,9 +120,8 @@
 ;; forward chainer function.
 (: fc_eq (-> Atom (-> Atom) Nat Atom))
 ;; Base case
-(= (fc_eq (→ $p $q) $kb $depth) (→ $p $q))
-(= (fc_eq $p $kb $depth) $p)
-;; Recursive case
+(= (fc_eq $premise $kb $depth) $premise)
+;; Recursive case (modus ponens)
 (= (fc_eq (→ $p $q) $kb (S $k)) (let $p (kb_eq) (fc_eq $q $kb $k)))
 (= (fc_eq $p $kb (S $k)) (let (→ $p $q) (kb_eq) (fc_eq $q $kb $k)))
 

--- a/metta/forward-chainer/forward-chainer-test.metta
+++ b/metta/forward-chainer/forward-chainer-test.metta
@@ -54,19 +54,25 @@
                 $q))
 
 ;; Test forward chainer
-!(fc_entail (⊢ A) kb_entail rb_entail (fromNumber 2))
-!(fc_entail (⊢ (→ A B)) kb_entail rb_entail (fromNumber 2))
+!(assertEqualToResult
+  (fc_entail (⊢ A) kb_entail rb_entail (fromNumber 2))
+  ((⊢ A) (⊢ B) (⊢ C)))
+!(assertEqualToResult
+  (fc_entail (⊢ (→ A B)) kb_entail rb_entail (fromNumber 2))
+  ((⊢ (→ A B)) (⊢ B) (⊢ C)))
 ;; !(fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2))
-!(let (⊢ (→ $x $y)) (kb_entail)
-      (fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2)))
+!(assertEqualToResult
+  (let (⊢ (→ $x $y)) (kb_entail)
+       (fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2)))
+  ((⊢ (→ A B)) (⊢ B) (⊢ C) (⊢ (→ B C))))
 
 ;;;;;;;;;;;;;;;;;
-;; Bare entail ;;
+;; Bare Entail ;;
 ;;;;;;;;;;;;;;;;;
 
 ;; Variant of entail where ⊢ is not wrapped around the knowledge base.
 
-! "=== Bare entail ==="
+! "=== Bare Entail ==="
 
 ;; Foward chainer
 (: fc_bare (-> Atom (-> Atom) (-> Atom) Nat Atom))
@@ -98,11 +104,16 @@
               $q))
 
 ;; Test forward chainer
-!(fc_bare A kb_bare rb_bare (fromNumber 2))
-!(fc_bare (→ A B) kb_bare rb_bare (fromNumber 2))
-;; !(fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2))
-!(let (→ $x $y) (kb_bare)
-      (fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2)))
+!(assertEqualToResult
+  (fc_bare A kb_bare rb_bare (fromNumber 2))
+  (A B C))
+!(assertEqualToResult
+  (fc_bare (→ A B) kb_bare rb_bare (fromNumber 2))
+  ((→ A B) B C))
+!(assertEqualToResult
+  (let (→ $x $y) (kb_bare)
+       (fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2)))
+  ((→ A B) B C (→ B C)))
 
 ;;;;;;;;;;;;;;
 ;; Equality ;;
@@ -126,15 +137,96 @@
 (= (fc_eq $p $kb (S $k)) (let (→ $p $q) (kb_eq) (fc_eq $q $kb $k)))
 
 ;; Test forward chainer
-!(fc_eq A kb_eq (fromNumber 2))
-!(fc_eq (→ A B) kb_eq (fromNumber 2))
-;; !(fc_eq (→ $x $y) kb_eq (fromNumber 2))
-!(let (→ $x $y) (kb_eq)
-      (fc_eq (→ $x $y) kb_eq (fromNumber 2)))
+!(assertEqualToResult
+  (fc_eq A kb_eq (fromNumber 2))
+  (A B C))
+!(assertEqualToResult
+  (fc_eq (→ A B) kb_eq (fromNumber 2))
+  ((→ A B) B C))
+!(assertEqualToResult
+  (let (→ $x $y) (kb_eq)
+       (fc_eq (→ $x $y) kb_eq (fromNumber 2)))
+  ((→ A B) B C (→ B C)))
 
-;;;;;;;;;;;
-;; Match ;;
-;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;
+;; Bare Entail Match ;;
+;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Like bare entail but let is replaced by match
+
+! "=== Bare Entail Match ==="
+
+;; Knowledge base
+!(bind! &kb_bem (new-space))
+!(add-atom &kb_bem (→ A B))
+!(add-atom &kb_bem (→ B C))
+!(add-atom &kb_bem A)
+
+;; Rule base
+!(bind! &rb_bem (new-space))
+!(add-atom &rb_bem (⊢
+                    ;; Premises
+                    (→ $p $q)
+                    $p
+                    ;; Conclusion
+                    $q))
+
+;; Forward chainer
+(: fc_bem (-> Atom Nat Atom))
+;; Base case
+(= (fc_bem $premise $depth) $premise)
+;; Recursive cases
+(= (fc_bem $premise1 (S $k))
+   (match &rb_bem (⊢ $premise1 $premise2 $conclusion)
+          (match &kb_bem $premise2 (fc_bem $conclusion $k))))
+(= (fc_bem $premise2 (S $k))
+   (match &rb_bem (⊢ $premise1 $premise2 $conclusion)
+          (match &kb_bem $premise1 (fc_bem $conclusion $k))))
+
+;; Test forward chainer
+!(assertEqualToResult
+  (fc_bem A (fromNumber 2))
+  (A B C))
+!(assertEqualToResult
+  (fc_bem (→ A B) (fromNumber 2))
+  ((→ A B) B C))
+!(assertEqualToResult
+  (match &kb_bem (→ $x $y) (fc_bem (→ $x $y) (fromNumber 2)))
+  ((→ B C) (→ A B) B C))
+
+;;;;;;;;;;;;;;;;;;;;
+;; Equality Match ;;
+;;;;;;;;;;;;;;;;;;;;
+
+;; Like equality but let is replaced by match
+
+! "=== Equality Match ==="
+
+;; Knowledge base
+!(bind! &kb_em (new-space))
+!(add-atom &kb_em (→ A B))
+!(add-atom &kb_em (→ B C))
+!(add-atom &kb_em A)
+
+;; Forward chainer.  The rule based is directly embedded in the
+;; forward chainer function.
+(: fc_em (-> Atom Nat Atom))
+;; Base case
+(= (fc_em $premise $depth) $premise)
+;; Recursive case (modus ponens)
+(= (fc_em (→ $p $q) (S $k)) (match &kb_em $p (fc_em $q $k)))
+(= (fc_em $p (S $k)) (match &kb_em (→ $p $q) (fc_em $q $k)))
+
+;; Test forward chainer
+!(assertEqualToResult
+  (fc_em A (fromNumber 2))
+  (A B C))
+!(assertEqualToResult
+  (fc_em (→ A B) (fromNumber 2))
+  ((→ A B) B C))
+!(assertEqualToResult
+  (match &kb_em (→ $x $y) (fc_em (→ $x $y) (fromNumber 2)))
+  ((→ A B) B C (→ B C)))
 
 ;;;;;;;;;
 ;; DTL ;;
@@ -172,8 +264,20 @@
                             $q)))
 
 ;; Test forward chainer
-!(fc_dtl (: a A) kb_dtl rb_dtl (fromNumber 2))
-!(fc_dtl (: ab (→ A B)) kb_dtl rb_dtl (fromNumber 2))
-;; !(fc_dtl (: $proof (→ $x $y)) kb_dtl rb_dtl (fromNumber 2))
-!(let (: $prf (→ $x $y)) (kb_dtl)
-      (fc_dtl (: $prf (→ $x $y)) kb_dtl rb_dtl (fromNumber 2)))
+!(assertEqualToResult
+  (fc_dtl (: a A) kb_dtl rb_dtl (fromNumber 2))
+  ((: a A)
+   (: (ModusPonens ab a) B)
+   (: (ModusPonens bc (ModusPonens ab a)) C)))
+!(assertEqualToResult
+  (fc_dtl (: ab (→ A B)) kb_dtl rb_dtl (fromNumber 2))
+  ((: ab (→ A B))
+   (: (ModusPonens ab a) B)
+   (: (ModusPonens bc (ModusPonens ab a)) C)))
+!(assertEqualToResult
+  (let (: $prf (→ $x $y)) (kb_dtl)
+       (fc_dtl (: $prf (→ $x $y)) kb_dtl rb_dtl (fromNumber 2)))
+  ((: ab (→ A B))
+   (: (ModusPonens ab a) B)
+   (: (ModusPonens bc (ModusPonens ab a)) C)
+   (: bc (→ B C))))

--- a/metta/forward-chainer/forward-chainer-test.metta
+++ b/metta/forward-chainer/forward-chainer-test.metta
@@ -1,0 +1,153 @@
+;;;;;;;;;
+;; Nat ;;
+;;;;;;;;;
+
+;; Define Nat
+(: Nat Type)
+(: Z Nat)
+(: S (-> Nat Nat))
+
+;; Define <=
+(: <= (-> $a $a Bool))
+(= (<= $x $y) (or (< $x $y) (== $x $y)))
+
+;; Define cast functions between Nat and Number
+(: fromNumber (-> Number Nat))
+(= (fromNumber $n) (if (<= $n 0) Z (S (fromNumber (- $n 1)))))
+(: fromNat (-> Nat Number))
+(= (fromNat Z) 0)
+(= (fromNat (S $k)) (+ 1 (fromNat $k)))
+
+;;;;;;;;;;;;;;;;;;;;
+;; Entail version ;;
+;;;;;;;;;;;;;;;;;;;;
+
+;; Foward chainer
+(: fc_entail (-> Atom (-> Atom) (-> Atom) Nat Atom))
+;; Base case
+(= (fc_entail (⊢ $premise) $kb $rb $depth) (⊢ $premise))
+;; Recursive cases
+(= (fc_entail (⊢ $premise1) $kb $rb (S $k))
+   (let* (((⊢ $premise1 $premise2 $conclusion) ($rb))
+          ((⊢ $premise2) ($kb)))
+     (fc_entail (⊢ $conclusion) $kb $rb $k)))
+(= (fc_entail (⊢ $premise2) $kb $rb (S $k))
+   (let* (((⊢ $premise1 $premise2 $conclusion) ($rb))
+          ((⊢ $premise1) ($kb)))
+     (fc_entail (⊢ $conclusion) $kb $rb $k)))
+
+;; Knowledge base
+(: kb_entail (-> Atom))
+(= (kb_entail) (superpose ((⊢ (→ A B))
+                           (⊢ (→ B C))
+                           (⊢ A))))
+
+;; Rule base (modus ponens)
+(: rb_entail (-> Atom))
+(= (rb_entail) (⊢
+                ;; Premises
+                (→ $p $q)
+                $p
+                ;; Conclusion
+                $q))
+
+;; Test forward chainer
+!(fc_entail (⊢ A) kb_entail rb_entail (fromNumber 2))
+!(fc_entail (⊢ (→ A B)) kb_entail rb_entail (fromNumber 2))
+;; !(fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2))
+!(let (⊢ (→ $x $y)) (kb_entail)
+      (fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Bare entail version ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Variant of entail where ⊢ is not wrapped around the knowledge base.
+
+;; Foward chainer
+(: fc_bare (-> Atom (-> Atom) (-> Atom) Nat Atom))
+;; Base case
+(= (fc_bare $premise $kb $rb $depth) $premise)
+;; Recursive cases
+(= (fc_bare $premise1 $kb $rb (S $k))
+   (let* (((⊢ $premise1 $premise2 $conclusion) ($rb))
+          ($premise2 ($kb)))
+     (fc_bare $conclusion $kb $rb $k)))
+(= (fc_bare $premise2 $kb $rb (S $k))
+   (let* (((⊢ $premise1 $premise2 $conclusion) ($rb))
+          ($premise1 ($kb)))
+     (fc_bare $conclusion $kb $rb $k)))
+
+;; Knowledge base
+(: kb_bare (-> Atom))
+(= (kb_bare) (superpose ((→ A B)
+                         (→ B C)
+                         A)))
+
+;; Rule base (modus ponens)
+(: rb_bare (-> Atom))
+(= (rb_bare) (⊢
+              ;; Premises
+              (→ $p $q)
+              $p
+              ;; Conclusion
+              $q))
+
+;; Test forward chainer
+!(fc_bare A kb_bare rb_bare (fromNumber 2))
+!(fc_bare (→ A B) kb_bare rb_bare (fromNumber 2))
+;; !(fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2))
+!(let (→ $x $y) (kb_bare)
+      (fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2)))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;
+;; ;; Equality version ;;
+;; ;;;;;;;;;;;;;;;;;;;;;;
+
+;; ;; Rule base (modus ponens)
+;; (= (,
+;;     ;; Premises
+;;     (→ $p $q)
+;;     $p)
+;;    ;; Conclusion
+;;    $q)
+
+;;;;;;;;;;;;;;;;;
+;; DTL version ;;
+;;;;;;;;;;;;;;;;;
+
+;; Foward chainer
+(: fc_dtl (-> Atom (-> Atom) (-> Atom) Nat Atom))
+;; Base case
+(= (fc_dtl (: $proof $premise) $kb $rb $depth) (: $proof $premise))
+;; Recursive cases
+(= (fc_dtl (: $proof1 $premise1) $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $conclusion)) ($rb))
+          ((: $proof2 $premise2) ($kb)))
+     (fc_dtl (: ($ructor $proof1 $proof2) $conclusion) $kb $rb $k)))
+(= (fc_dtl (: $proof2 $premise2) $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $conclusion)) ($rb))
+          ((: $proof1 $premise1) ($kb)))
+     (fc_dtl (: ($ructor $proof1 $proof2) $conclusion) $kb $rb $k)))
+
+;; Knowledge base
+(: kb_dtl (-> Atom))
+(= (kb_dtl) (superpose ((: ab (→ A B))
+                        (: bc (→ B C))
+                        (: a A))))
+
+;; Rule base
+(: rb_dtl (-> Atom))
+(= (rb_dtl) (: ModusPonens (->
+                            ;; Premises
+                            (→ $p $q)
+                            $p
+                            ;; Conclusion
+                            $q)))
+
+;; Test forward chainer
+!(fc_dtl (: a A) kb_dtl rb_dtl (fromNumber 2))
+!(fc_dtl (: ab (→ A B)) kb_dtl rb_dtl (fromNumber 2))
+;; !(fc_dtl (: $proof (→ $x $y)) kb_dtl rb_dtl (fromNumber 2))
+!(let (: $prf (→ $x $y)) (kb_dtl)
+      (fc_dtl (: $prf (→ $x $y)) kb_dtl rb_dtl (fromNumber 2)))

--- a/metta/forward-chainer/forward-chainer-test.metta
+++ b/metta/forward-chainer/forward-chainer-test.metta
@@ -18,9 +18,11 @@
 (= (fromNat Z) 0)
 (= (fromNat (S $k)) (+ 1 (fromNat $k)))
 
-;;;;;;;;;;;;;;;;;;;;
-;; Entail version ;;
-;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;
+;; Entail ;;
+;;;;;;;;;;;;
+
+! "=== Entail ==="
 
 ;; Foward chainer
 (: fc_entail (-> Atom (-> Atom) (-> Atom) Nat Atom))
@@ -42,7 +44,7 @@
                            (⊢ (→ B C))
                            (⊢ A))))
 
-;; Rule base (modus ponens)
+;; Rule base
 (: rb_entail (-> Atom))
 (= (rb_entail) (⊢
                 ;; Premises
@@ -58,11 +60,13 @@
 !(let (⊢ (→ $x $y)) (kb_entail)
       (fc_entail (⊢ (→ $x $y)) kb_entail rb_entail (fromNumber 2)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Bare entail version ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;
+;; Bare entail ;;
+;;;;;;;;;;;;;;;;;
 
 ;; Variant of entail where ⊢ is not wrapped around the knowledge base.
+
+! "=== Bare entail ==="
 
 ;; Foward chainer
 (: fc_bare (-> Atom (-> Atom) (-> Atom) Nat Atom))
@@ -84,7 +88,7 @@
                          (→ B C)
                          A)))
 
-;; Rule base (modus ponens)
+;; Rule base
 (: rb_bare (-> Atom))
 (= (rb_bare) (⊢
               ;; Premises
@@ -100,21 +104,44 @@
 !(let (→ $x $y) (kb_bare)
       (fc_bare (→ $x $y) kb_bare rb_bare (fromNumber 2)))
 
-;; ;;;;;;;;;;;;;;;;;;;;;;
-;; ;; Equality version ;;
-;; ;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;
+;; Equality ;;
+;;;;;;;;;;;;;;
 
-;; ;; Rule base (modus ponens)
-;; (= (,
-;;     ;; Premises
-;;     (→ $p $q)
-;;     $p)
-;;    ;; Conclusion
-;;    $q)
+! "=== Equality ==="
 
-;;;;;;;;;;;;;;;;;
-;; DTL version ;;
-;;;;;;;;;;;;;;;;;
+;; Knowledge base
+(: kb_eq (-> Atom))
+(= (kb_eq) (superpose ((→ A B)
+                       (→ B C)
+                       A)))
+
+;; Forward chainer.  The rule based is directly embedded in the
+;; forward chainer function.
+(: fc_eq (-> Atom (-> Atom) Nat Atom))
+;; Base case
+(= (fc_eq (→ $p $q) $kb $depth) (→ $p $q))
+(= (fc_eq $p $kb $depth) $p)
+;; Recursive case
+(= (fc_eq (→ $p $q) $kb (S $k)) (let $p (kb_eq) (fc_eq $q $kb $k)))
+(= (fc_eq $p $kb (S $k)) (let (→ $p $q) (kb_eq) (fc_eq $q $kb $k)))
+
+;; Test forward chainer
+!(fc_eq A kb_eq (fromNumber 2))
+!(fc_eq (→ A B) kb_eq (fromNumber 2))
+;; !(fc_eq (→ $x $y) kb_eq (fromNumber 2))
+!(let (→ $x $y) (kb_eq)
+      (fc_eq (→ $x $y) kb_eq (fromNumber 2)))
+
+;;;;;;;;;;;
+;; Match ;;
+;;;;;;;;;;;
+
+;;;;;;;;;
+;; DTL ;;
+;;;;;;;;;
+
+! "=== DTL ==="
 
 ;; Foward chainer
 (: fc_dtl (-> Atom (-> Atom) (-> Atom) Nat Atom))

--- a/metta/match/DeductionImplicationDirectIntroductionMatchTest.metta
+++ b/metta/match/DeductionImplicationDirectIntroductionMatchTest.metta
@@ -9,12 +9,12 @@
 (∉ 42 Empty)
 
 ; Q->R is already in the atomspace
-(≞ (→ Q R) (PrCnt 1 0.5))
+(≞ (→ Q R) (STV 1 0.5))
 
 ; Predicates
-(≞ P (PrCnt 1 0.1))
-(≞ Q (PrCnt 1 0.5))
-(≞ R (PrCnt 1 0.1))
+(≞ P (STV 1 0.1))
+(≞ Q (STV 1 0.5))
+(≞ R (STV 1 0.1))
 
 ; Matching query to do IDI and deduction rules
 !(match &self

--- a/metta/match/DeductionMatchTest.metta
+++ b/metta/match/DeductionMatchTest.metta
@@ -1,11 +1,11 @@
 ;; Test Deduction match Rule
 !(import! &self DeductionMatch.metta)
 
-(≞ P (PrCnt 1 0.1))
-(≞ Q (PrCnt 1 0.1))
-(≞ R (PrCnt 1 0.1))
-(≞ (→ P Q) (PrCnt 1 0.5))
-(≞ (→ Q R) (PrCnt 1 0.5))
+(≞ P (STV 1 0.1))
+(≞ Q (STV 1 0.1))
+(≞ R (STV 1 0.1))
+(≞ (→ P Q) (STV 1 0.5))
+(≞ (→ Q R) (STV 1 0.5))
 
 !(deduction_match &self)
 

--- a/metta/match/ImplicationDirectIntroductionMatch.metta
+++ b/metta/match/ImplicationDirectIntroductionMatch.metta
@@ -28,11 +28,11 @@
 
 ;; Base case (axiomatic rule):
 ;;
-;; p→q ≞ (ETV Empty (PrCnt 1 0))
+;; p→q ≞ (ETV Empty (STV 1 0))
 ;;
 ;; Directly present in the atomspace.
 (= (idi_axiom)
-   (≞ (→ $p $q) (ETV Empty (PrCnt 1 0))))
+   (≞ (→ $p $q) (ETV Empty (STV 1 0))))
 
 ;; Recursive case (inductive rule):
 ;;

--- a/metta/match/ImplicationDirectIntroductionMatchTest.metta
+++ b/metta/match/ImplicationDirectIntroductionMatchTest.metta
@@ -3,7 +3,7 @@
 
 (≞ (P 42) (Bl True))
 (≞ (Q 42) (Bl False))
-(≞ (→ P Q) (ETV Empty (PrCnt 1 0)))
+(≞ (→ P Q) (ETV Empty (STV 1 0)))
 (∉ 42 Empty)
 
 !(idi_induction_match &self)

--- a/metta/sumo/README.md
+++ b/metta/sumo/README.md
@@ -64,6 +64,13 @@ are products, disjunctions are Either, etc.
 A set of rules have been specially crafted to reason over SUMO and
 contained into `rules.metta`.
 
+## Prerequisite
+
+Make sure that hyperon-experimental has been compiled with
+`variable_operator` disabled.  To check that, search for `[features]`
+and make sure that `default` excludes `"variable_operation"` inside
+the `<HYPERON-EXPERIMENTAL>/lib/Cargo.toml` file.
+
 ## Usage
 
 See the README.md files under the subfolders of the experiments

--- a/metta/synthesis/Synthesize.metta
+++ b/metta/synthesis/Synthesize.metta
@@ -16,14 +16,12 @@
 ;;         4. Type checking: (: TERM TYPE)
 ;;         5. Type inference: (: TERM $type)
 ;;
-;; $axiom: a nullary function to axiom, to non-deterministically pick
-;;         up an axiom.  An axiom is an Atom of the form
-;;         (: TERM TYPE).
+;; $kb: a nullary function to axiom, to non-deterministically pick up
+;;      an axiom.  An axiom is an Atom of the form (: TERM TYPE).
 ;;
-;; $rule: a nullary function to rule, to non-deterministically pick up
-;;        a rule.  A rule is a function mapping premises to
-;;        conclusion, where premises and conclusion have the form
-;;        (: TERM TYPE).
+;; $rb: a nullary function to rule, to non-deterministically pick up a
+;;      rule.  A rule is a function mapping premises to conclusion,
+;;      where premises and conclusion have the form (: TERM TYPE).
 ;;
 ;; $depth: a Nat representing the maximum depth of the generated
 ;;         programs.
@@ -32,45 +30,45 @@
 ;; tuples.
 (: synthesize (-> Atom (-> Atom) (-> Atom) Nat Atom))
 ;; Nullary rule (axiom)
-(= (synthesize $query $axiom $rule $depth)
-   (let $query ($axiom) $query))
+(= (synthesize $query $kb $rb $depth)
+   (let $query ($kb) $query))
 ;; Unary rule
-(= (synthesize $query $axiom $rule (S $k))
-   (let* (((: $ructor (-> $premise $conclusion)) ($rule))
+(= (synthesize $query $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise $conclusion)) ($rb))
           ((: ($ructor $proof) $conclusion) $query)
-          ((: $proof $premise) (synthesize (: $proof $premise) $axiom $rule $k)))
+          ((: $proof $premise) (synthesize (: $proof $premise) $kb $rb $k)))
      $query))
 ;; Binary rule
-(= (synthesize $query $axiom $rule (S $k))
-   (let* (((: $ructor (-> $premise1 $premise2 $conclusion)) ($rule))
+(= (synthesize $query $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $conclusion)) ($rb))
           ((: ($ructor $proof1 $proof2) $conclusion) $query)
-          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $axiom $rule $k))
-          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $axiom $rule $k)))
+          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $kb $rb $k))
+          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $kb $rb $k)))
      $query))
 ;; Trinary rule
-(= (synthesize $query $axiom $rule (S $k))
-   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $conclusion)) ($rule))
+(= (synthesize $query $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $conclusion)) ($rb))
           ((: ($ructor $proof1 $proof2 $proof3) $conclusion) $query)
-          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $axiom $rule $k))
-          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $axiom $rule $k))
-          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $axiom $rule $k)))
+          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $kb $rb $k))
+          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $kb $rb $k))
+          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $kb $rb $k)))
      $query))
 ;; Quaternary rule
-(= (synthesize $query $axiom $rule (S $k))
-   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $premise4 $conclusion)) ($rule))
+(= (synthesize $query $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $premise4 $conclusion)) ($rb))
           ((: ($ructor $proof1 $proof2 $proof3 $proof4) $conclusion) $query)
-          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $axiom $rule $k))
-          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $axiom $rule $k))
-          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $axiom $rule $k))
-          ((: $proof4 $premise4) (synthesize (: $proof4 $premise4) $axiom $rule $k)))
+          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $kb $rb $k))
+          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $kb $rb $k))
+          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $kb $rb $k))
+          ((: $proof4 $premise4) (synthesize (: $proof4 $premise4) $kb $rb $k)))
      $query))
 ;; Quintenary rule
-(= (synthesize $query $axiom $rule (S $k))
-   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $premise4 $premise5 $conclusion)) ($rule))
+(= (synthesize $query $kb $rb (S $k))
+   (let* (((: $ructor (-> $premise1 $premise2 $premise3 $premise4 $premise5 $conclusion)) ($rb))
           ((: ($ructor $proof1 $proof2 $proof3 $proof4 $proof5) $conclusion) $query)
-          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $axiom $rule $k))
-          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $axiom $rule $k))
-          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $axiom $rule $k))
-          ((: $proof4 $premise4) (synthesize (: $proof4 $premise4) $axiom $rule $k))
-          ((: $proof5 $premise5) (synthesize (: $proof5 $premise5) $axiom $rule $k)))
+          ((: $proof1 $premise1) (synthesize (: $proof1 $premise1) $kb $rb $k))
+          ((: $proof2 $premise2) (synthesize (: $proof2 $premise2) $kb $rb $k))
+          ((: $proof3 $premise3) (synthesize (: $proof3 $premise3) $kb $rb $k))
+          ((: $proof4 $premise4) (synthesize (: $proof4 $premise4) $kb $rb $k))
+          ((: $proof5 $premise5) (synthesize (: $proof5 $premise5) $kb $rb $k)))
      $query))


### PR DESCRIPTION
Here are the main (interesting) ways:
* Dependently Typed Language: like the synthesizer but going only forward.
* Entail: knowledge and rules are represented with the `⊢` relationship.  Forward chainer provides only conclusions, the proofs are run-time traces and therefore ephemeral.
* Equality: like entail but the rules are directly embedded into the forward chainer.
* Equality Match: like equality but the knowledge is stored in its own space.