### PR TITLE
First experiments about inference control

### DIFF
--- a/metta/backward-chaining/README.md
+++ b/metta/backward-chaining/README.md
@@ -33,3 +33,15 @@ metta bc-xp.metta
 ```
 
 It should outputs empty results indicating that all tests have passed.
+
+## Related
+
+In the `iterative-chaining` experiments, a new implementation of the
+backward chainer was discovered which recurses on rule abstraction
+(not just rule premises) and uses currying to simplify the
+implementation.  See `syn` in `ibc-xp.metta`.
+
+Also, in the `hol` experiments, it was discovered that proof reduction
+(simplifying a proof to reach a canonical form) can be achieved by
+defining reduction rules as traditional function definitions, and thus
+let MeTTa interper spontaneously reduce them.

--- a/metta/hol/NatStandaloneTest.metta
+++ b/metta/hol/NatStandaloneTest.metta
@@ -271,9 +271,11 @@
 ;;
 ;; ((NatInd ((Replace0 (Sym plusRightIdProp)) plusBase)) ((. (Replace0 (Sym plusRightIdProp))) ((. (Trans plusRec)) ((. Cong) (Replace0 plusRightIdProp)))))
 ;;
-;; We provide half of the proof otherwise the search takes too much memory (over 64GB)
+;; We provide the clue that structural induction is to be so that the
+;; backward chainer only has to find the base case and the inductive
+;; step, otherwise the search takes too much memory (over 64GB).
 !(assertEqual
-  (bc (: ((NatInd ((Replace0 (Sym plusRightIdProp)) plusBase)) $subprf) (plusRightId $x)) (fromNumber 5))
+  (bc (: ((NatInd $basecase) $indstep) (plusRightId $x)) (fromNumber 5))
   (: ((NatInd ((Replace0 (Sym plusRightIdProp)) plusBase)) ((. (Replace0 (Sym plusRightIdProp))) ((. (Trans plusRec)) ((. Cong) (Replace0 plusRightIdProp))))) (plusRightId $x)))
 
 ;; TODO: try to reproduce

--- a/metta/inference-control/README.md
+++ b/metta/inference-control/README.md
@@ -1,0 +1,9 @@
+# Inference Control Experiments
+
+## Description
+
+First, we experiment with inference control as pruning mechanism.  The
+simplest way to do that is to replace the maximum depth by a
+termination predicate.  It is unclear what should be the domain of
+that termination predicate.  Should it be the proof so far?  Something
+external?  Best is to let it user defined.

--- a/metta/inference-control/inf-ctl-month-xp.metta
+++ b/metta/inference-control/inf-ctl-month-xp.metta
@@ -31,28 +31,28 @@
 ;; !(add-atom &kb (: Dec Month))
 
 ;; January precedes February, which precedes Mars, etc.
-!(add-atom &kb (: jf (≺ Jan Feb)))
-!(add-atom &kb (: fm (≺ Feb Mar)))
-!(add-atom &kb (: ma (≺ Mar Apr)))
-!(add-atom &kb (: am (≺ Apr May)))
-!(add-atom &kb (: mj (≺ May Jun)))
-!(add-atom &kb (: jj (≺ Jun Jul)))
-!(add-atom &kb (: ja (≺ Jul Aug)))
-!(add-atom &kb (: as (≺ Aug Sep)))
-!(add-atom &kb (: so (≺ Sep Oct)))
-!(add-atom &kb (: on (≺ Oct Nov)))
-!(add-atom &kb (: nd (≺ Nov Dec)))
+!(add-atom &kb (: jf (≼ Jan Feb)))
+!(add-atom &kb (: fm (≼ Feb Mar)))
+!(add-atom &kb (: ma (≼ Mar Apr)))
+!(add-atom &kb (: am (≼ Apr May)))
+!(add-atom &kb (: mj (≼ May Jun)))
+!(add-atom &kb (: jj (≼ Jun Jul)))
+!(add-atom &kb (: ja (≼ Jul Aug)))
+!(add-atom &kb (: as (≼ Aug Sep)))
+!(add-atom &kb (: so (≼ Sep Oct)))
+!(add-atom &kb (: on (≼ Oct Nov)))
+!(add-atom &kb (: nd (≼ Nov Dec)))
 
 ;; Precedence is non strict, i.e. reflexive
-!(add-atom &kb (: Relf (≺ $x $x)))
+!(add-atom &kb (: Relf (≼ $x $x)))
 
 ;; Precedence is transitive
-!(add-atom &kb (: Trans (-> (≺ $x $y)
-                            (-> (≺ $y $z)
-                                (≺ $x $z)))))
+!(add-atom &kb (: Trans (-> (≼ $x $y)
+                            (-> (≼ $y $z)
+                                (≼ $x $z)))))
 
 ;; Shortcut rule: January precedes all months
-!(add-atom &kb (: JPA (≺ Jan $x)))
+!(add-atom &kb (: JPA (≼ Jan $x)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Backward Controlled Chainer ;;

--- a/metta/inference-control/inf-ctl-month-xp.metta
+++ b/metta/inference-control/inf-ctl-month-xp.metta
@@ -13,38 +13,21 @@
 ;; Knowledge and rule base
 !(bind! &kb (new-space))
 
-;; For now we try to define the problem without having to define
-;; Month.
-;;
-;; ;; January, February, etc, are months
-;; !(add-atom &kb (: Jan Month))
-;; !(add-atom &kb (: Feb Month))
-;; !(add-atom &kb (: Mar Month))
-;; !(add-atom &kb (: Apr Month))
-;; !(add-atom &kb (: May Month))
-;; !(add-atom &kb (: Jun Month))
-;; !(add-atom &kb (: Jul Month))
-;; !(add-atom &kb (: Aug Month))
-;; !(add-atom &kb (: Sep Month))
-;; !(add-atom &kb (: Oct Month))
-;; !(add-atom &kb (: Nov Month))
-;; !(add-atom &kb (: Dec Month))
-
 ;; January precedes February, which precedes Mars, etc.
-!(add-atom &kb (: jf (≼ Jan Feb)))
-!(add-atom &kb (: fm (≼ Feb Mar)))
-!(add-atom &kb (: ma (≼ Mar Apr)))
-!(add-atom &kb (: am (≼ Apr May)))
-!(add-atom &kb (: mj (≼ May Jun)))
-!(add-atom &kb (: jj (≼ Jun Jul)))
-!(add-atom &kb (: ja (≼ Jul Aug)))
-!(add-atom &kb (: as (≼ Aug Sep)))
-!(add-atom &kb (: so (≼ Sep Oct)))
-!(add-atom &kb (: on (≼ Oct Nov)))
-!(add-atom &kb (: nd (≼ Nov Dec)))
+!(add-atom &kb (: JF (≼ Jan Feb)))
+!(add-atom &kb (: FM (≼ Feb Mar)))
+!(add-atom &kb (: MA (≼ Mar Apr)))
+!(add-atom &kb (: AM (≼ Apr May)))
+!(add-atom &kb (: MJ (≼ May Jun)))
+!(add-atom &kb (: JJ (≼ Jun Jul)))
+!(add-atom &kb (: JA (≼ Jul Aug)))
+!(add-atom &kb (: AS (≼ Aug Sep)))
+!(add-atom &kb (: SO (≼ Sep Oct)))
+!(add-atom &kb (: ON (≼ Oct Nov)))
+!(add-atom &kb (: ND (≼ Nov Dec)))
 
 ;; Precedence is non strict, i.e. reflexive
-!(add-atom &kb (: Relf (≼ $x $x)))
+!(add-atom &kb (: Refl (≼ $x $x)))
 
 ;; Precedence is transitive
 !(add-atom &kb (: Trans (-> (≼ $x $y)
@@ -170,4 +153,215 @@
 (= (fromNat Z) 0)
 (= (fromNat (S $k)) (+ 1 (fromNat $k)))
 
-;; NEXT
+;;;;;;;;;;;
+;; Tests ;;
+;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Context is depth ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; The context is the maximum depth, thus reproduces the experiments
+;; done so far.  Note that a depth of 1, not 0, allows to query the
+;; KB.
+
+;; Define context updater, same for both for proof abstraction and
+;; argument.  Decrement the depth.
+(: dec (-> Nat Nat))
+(= (dec Z) Z)
+(= (dec (S $k)) $k)
+(: depth-updater (-> $a Nat Nat))
+(= (depth-updater $query $depth) (dec $depth))
+
+;; Define termination predicate, called inside a conditional wrapping
+;; the bc.  Terminates at 0.
+(: is-zero (-> Nat Bool))
+(= (is-zero Z) True)
+(= (is-zero (S $k)) False)
+(: depth-terminator (-> $a Nat Bool))
+(= (depth-terminator $query $depth) (is-zero $depth))
+
+;; Prove that Jan non-strictly precedes Jan
+!(assertEqualToResult
+  (bc depth-updater depth-updater depth-terminator
+      (fromNumber 2)
+      (: $prf (≼ Jan Jan)))
+  ((: JPA (≼ Jan Jan))
+   (: Refl (≼ Jan Jan))))
+
+;; Prove that Feb non-strictly precedes Feb
+!(assertEqual
+  (bc depth-updater depth-updater depth-terminator
+      (fromNumber 2)
+      (: $prf (≼ Feb Feb)))
+  (: Refl (≼ Feb Feb)))
+
+;; Prove that Jan precedes Feb
+!(assertEqualToResult
+  (bc depth-updater depth-updater depth-terminator
+      (fromNumber 2)
+      (: $prf (≼ Jan Feb)))
+  ((: JF (≼ Jan Feb))
+   (: JPA (≼ Jan Feb))))
+
+;; Prove that Jan precedes Mar
+!(assertEqualToResult
+  (bc depth-updater depth-updater depth-terminator
+      (fromNumber 3)
+      (: $prf (≼ Jan Mar)))
+  ((: ((Trans Refl) JPA) (≼ Jan Mar))
+   (: ((Trans JPA) FM) (≼ Jan Mar))
+   (: ((Trans JPA) Refl) (≼ Jan Mar))
+   (: ((Trans JPA) JPA) (≼ Jan Mar))
+   (: ((Trans JF) FM) (≼ Jan Mar))
+   (: JPA (≼ Jan Mar))))
+
+;; Prove that Feb precedes May
+!(assertEqual
+  (bc depth-updater depth-updater depth-terminator
+      (fromNumber 4)
+      (: $prf (≼ Feb May)))
+  (: ((Trans FM) ((Trans MA) AM)) (≼ Feb May)))
+
+;; Prove that Feb precedes Jun
+;; !(assertEqualToResult
+  !(bc depth-updater depth-updater depth-terminator
+      (fromNumber 5)
+      (: $prf (≼ Feb Jun)))
+;; (: ((Trans ((Trans FM) MA)) ((Trans AM) MJ)) (≼ Feb Jun))
+
+;; Prove that Feb precedes Jul
+;; !(assertEqual
+  !(bc depth-updater depth-updater depth-terminator
+      (fromNumber 6)
+      (: $prf (≼ Feb Jul)))
+  ;; (: ((Trans FM) ((Trans MA) ((Trans AM) ((Trans MJ) JJ)))) (≼ Feb Jul))
+
+;; Disabled because it takes 3h.
+;;
+;; ;; Prove that Feb precedes Aug
+;; ;; !(assertEqual
+;;   !(bc depth-updater depth-updater depth-terminator
+;;       (fromNumber 7)
+;;       (: $prf (≼ Feb Aug)))
+;;   ;; (: ((Trans FM) ((Trans MA) ((Trans AM) ((Trans MJ) JJ)))) (≼ Feb Jul))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Context is depth and target theorem ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; From the above experiment we make the following observations:
+;;
+;; 1. Refl is useful iff the theorem is (≼ x x).
+;;
+;; 2. For theorems (≼ Jan x), JPA is enough.
+;;
+;; 3. Otherwise, Trans is enough.
+
+;; Context type and ctor
+(: TD Type)
+(: MkTD (-> $a                     ; Target theorem
+            Nat                    ; Maximum depth
+            TD))
+
+;; Define context updater, same for both proof abstraction and proof
+;; argument.  Decrement the depth, leave the target theorem unchanged.
+(: td-updater (-> $a TD TD))
+(= (td-updater $query (MkTD $trg-thm $depth))
+   (MkTD $trg-thm (dec $depth)))
+
+;; Define termination predicate.  Terminate at depth 0, and respect
+;; the 3 observations above.
+(: td-terminator (-> $a TD Bool))
+(= (td-terminator (: $prf $thm) (MkTD $trg-thm $depth))
+   (or ;; Terminate at depth 0
+       (is-zero $depth)
+       (if (≐ $trg-thm (≼ $x $x))
+           ;; [1st observation] If the target theorem is (≼ x x) and
+           ;; current proof is Trans or JPA then terminate.
+           (or (== $prf Trans) (== $prf JPA))
+           (if (≐ $trg-thm (≼ Jan $y))
+               ;; [2nd observation] If the target theorem is (≼ Jan x)
+               ;; and current proof is Trans or Refl then terminate.
+               (or (== $prf Trans) (== $prf Refl))
+               ;; [3th observation] Otherwise, Trans is enough.
+               (or (== $prf JPA) (== $prf Refl))))))
+
+;; Prove that Jan non-strictly precedes Jan
+!(assertEqual
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Jan Jan) (fromNumber 2))
+      (: $prf (≼ Jan Jan)))
+  (: Refl (≼ Jan Jan)))
+
+;; Prove that Feb non-strictly precedes Feb
+!(assertEqual
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Feb Feb) (fromNumber 2))
+      (: $prf (≼ Feb Feb)))
+  (: Refl (≼ Feb Feb)))
+
+;; Prove that Jan precedes Feb
+!(assertEqualToResult
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Jan Feb) (fromNumber 2))
+      (: $prf (≼ Jan Feb)))
+  ((: JF (≼ Jan Feb))
+   (: JPA (≼ Jan Feb))))
+
+;; Prove that Jan precedes Mar
+!(assertEqual
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Jan Mar) (fromNumber 4))
+      (: $prf (≼ Jan Mar)))
+  (: JPA (≼ Jan Mar)))
+
+;; Prove that Feb precedes May
+!(assertEqual
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Feb May) (fromNumber 4))
+      (: $prf (≼ Feb May)))
+  (: ((Trans FM) ((Trans MA) AM)) (≼ Feb May)))
+
+;; Prove that Feb precedes Jun
+!(assertEqualToResult
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Feb Jun) (fromNumber 5))
+      (: $prf (≼ Feb Jun)))
+  ((: ((Trans ((Trans FM) MA)) ((Trans AM) MJ)) (≼ Feb Jun))
+   (: ((Trans FM) ((Trans MA) ((Trans AM) MJ))) (≼ Feb Jun))))
+
+;; Prove that Feb precedes Jul
+!(assertEqualToResult
+  (bc td-updater td-updater td-terminator
+      (MkTD (≼ Feb Jul) (fromNumber 6))
+      (: $prf (≼ Feb Jul)))
+  ((: ((Trans ((Trans FM) ((Trans MA) AM))) ((Trans MJ) JJ)) (≼ Feb Jul))
+   (: ((Trans ((Trans FM) MA)) ((Trans ((Trans AM) MJ)) JJ)) (≼ Feb Jul))
+   (: ((Trans ((Trans FM) MA)) ((Trans AM) ((Trans MJ) JJ))) (≼ Feb Jul))
+   (: ((Trans FM) ((Trans ((Trans MA) AM)) ((Trans MJ) JJ))) (≼ Feb Jul))
+   (: ((Trans FM) ((Trans MA) ((Trans AM) ((Trans MJ) JJ)))) (≼ Feb Jul))))
+
+;; Disabled because it takes 1h40.
+;;
+;; ;; Prove that Feb precedes Aug
+;; ;; !(assertEqual
+;;   !(bc td-updater td-updater td-terminator
+;;       (MkTD (≼ Feb Aug) (fromNumber 7))
+;;       (: $prf (≼ Feb Aug)))
+   ;; ((: ((Trans ((Trans ((Trans FM) MA)) ((Trans AM) ((Trans MJ) JJ)))) JA) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans ((Trans FM) MA)) ((Trans AM) MJ))) ((Trans JJ) JA)) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans ((Trans FM) MA)) AM)) ((Trans ((Trans MJ) JJ)) JA)) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans ((Trans FM) MA)) AM)) ((Trans MJ) ((Trans JJ) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) ((Trans MA) ((Trans AM) MJ)))) ((Trans JJ) JA)) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) ((Trans MA) AM))) ((Trans ((Trans MJ) JJ)) JA)) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) ((Trans MA) AM))) ((Trans MJ) ((Trans JJ) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) MA)) ((Trans ((Trans AM) ((Trans MJ) JJ))) JA)) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) MA)) ((Trans ((Trans AM) MJ)) ((Trans JJ) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) MA)) ((Trans AM) ((Trans ((Trans MJ) JJ)) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans ((Trans FM) MA)) ((Trans AM) ((Trans MJ) ((Trans JJ) JA)))) (≼ Feb Aug))
+   ;;  (: ((Trans FM) ((Trans ((Trans MA) ((Trans AM) MJ))) ((Trans JJ) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans FM) ((Trans ((Trans MA) AM)) ((Trans ((Trans MJ) JJ)) JA))) (≼ Feb Aug))
+   ;;  (: ((Trans FM) ((Trans ((Trans MA) AM)) ((Trans MJ) ((Trans JJ) JA)))) (≼ Feb Aug))
+   ;;  (: ((Trans FM) ((Trans MA) ((Trans ((Trans AM) MJ)) ((Trans JJ) JA)))) (≼ Feb Aug))
+   ;;  (: ((Trans FM) ((Trans MA) ((Trans AM) ((Trans MJ) ((Trans JJ) JA))))) (≼ Feb Aug)))

--- a/metta/inference-control/inf-ctl-month-xp.metta
+++ b/metta/inference-control/inf-ctl-month-xp.metta
@@ -1,0 +1,173 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Inference control experiments.  Attempt to reproduce the OpenCog
+;; Classic inference control meta learning
+;; https://github.com/opencog/pln/tree/master/examples/pln/inference-control-meta-learning
+;;
+;; Letters are replaced by months.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Knowledge and Rule Base ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Knowledge and rule base
+!(bind! &kb (new-space))
+
+;; For now we try to define the problem without having to define
+;; Month.
+;;
+;; ;; January, February, etc, are months
+;; !(add-atom &kb (: Jan Month))
+;; !(add-atom &kb (: Feb Month))
+;; !(add-atom &kb (: Mar Month))
+;; !(add-atom &kb (: Apr Month))
+;; !(add-atom &kb (: May Month))
+;; !(add-atom &kb (: Jun Month))
+;; !(add-atom &kb (: Jul Month))
+;; !(add-atom &kb (: Aug Month))
+;; !(add-atom &kb (: Sep Month))
+;; !(add-atom &kb (: Oct Month))
+;; !(add-atom &kb (: Nov Month))
+;; !(add-atom &kb (: Dec Month))
+
+;; January precedes February, which precedes Mars, etc.
+!(add-atom &kb (: jf (≺ Jan Feb)))
+!(add-atom &kb (: fm (≺ Feb Mar)))
+!(add-atom &kb (: ma (≺ Mar Apr)))
+!(add-atom &kb (: am (≺ Apr May)))
+!(add-atom &kb (: mj (≺ May Jun)))
+!(add-atom &kb (: jj (≺ Jun Jul)))
+!(add-atom &kb (: ja (≺ Jul Aug)))
+!(add-atom &kb (: as (≺ Aug Sep)))
+!(add-atom &kb (: so (≺ Sep Oct)))
+!(add-atom &kb (: on (≺ Oct Nov)))
+!(add-atom &kb (: nd (≺ Nov Dec)))
+
+;; Precedence is non strict, i.e. reflexive
+!(add-atom &kb (: Relf (≺ $x $x)))
+
+;; Precedence is transitive
+!(add-atom &kb (: Trans (-> (≺ $x $y)
+                            (-> (≺ $y $z)
+                                (≺ $x $z)))))
+
+;; Shortcut rule: January precedes all months
+!(add-atom &kb (: JPA (≺ Jan $x)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Backward Controlled Chainer ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Backward Chainer.  The arguments of the backward chainer are:
+;;
+;; * Context abstraction updater.  Given the current query and
+;;   context, update the context before recursively calling the
+;;   backward chainer on the proof abstraction.
+;;
+;; * Context argument updater.  Given the current query and context,
+;;   update the context before recursively calling the backward
+;;   chainer on the proof argument.
+;;
+;; * Termination predicate.  Given the current query and context,
+;;   provide the condition of a conditional wrapping the base case and
+;;   recursive step functions (pre-application), as well its results
+;;   (post-application).  Terminating amounts to pruning the reduction
+;;   (as in evaluation) branches.  For now there is only one
+;;   termination predicate for both pre and post application, in the
+;;   future we may want to separate it in two.
+;;
+;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables that may be
+;;   filled by the backward chainer.
+;;
+;; * Context: a context to be updated and passed to the recursive
+;;   calls of the backward chainer.
+;;
+;; The choice of the arguments of the context updaters and the
+;; termination predicate is justified as follows.  Context updaters
+;; take first the query, which can be viewed an updater modulator,
+;; which then takes the actual context to the return updated one.  An
+;; alternative would have been to construct a contextualized query,
+;; and update that contextualized query instead.  However, we do not
+;; do that to guaranty that the user-programmed inference control does
+;; not interfere with the correctness of the chainer.
+(: bc (-> (-> $a $ct $ct)      ; Context abstraction updater
+          (-> $a $ct $ct)      ; Context argument updater
+          (-> $a $ct Bool)     ; Termination predicate
+          $ct                  ; Context
+          $a                   ; Query
+          $a))                 ; Query result
+
+;; Base case.  Terminates no matter what, either by pruning the branch
+;; or by querying the kb.  Thanks to non-determinism, terminating the
+;; branch does not terminate alternative branches.
+(= (bc $absupd $argupd $tmnpred $ctx (: $prf $ccln))
+   ;; Pre-application termination conditional
+   (if ($tmnpred (: $prf $ccln) $ctx)
+       ;; Terminate by pruning the branch
+       (empty)
+       ;; Continue by querying the kb
+       (match &kb (: $prf $ccln)
+              ;; Post-application termination conditional
+              (if ($tmnpred (: $prf $ccln) $ctx)
+                  ;; Terminate by pruning the branch
+                  (empty)
+                  ;; Continue by returning the queried result
+                  (: $prf $ccln)))))
+
+;; Recursive step.  Recursion only happens if the termination
+;; condition is false.  Otherwise, the branch is pruned.
+(= (bc $absupd $argupd $tmnpred $ctx (: ($prfabs $prfarg) $ccln))
+   ;; Pre-application termination conditional
+   (if ($tmnpred (: ($prfabs $prfarg) $ccln) $ctx)
+       ;; Terminate by pruning the branch
+       (empty)
+       ;; Continue by recursing
+       (let* (;; Recurse on proof abstraction
+              ((: $prfabs (-> $prms $ccln))
+               (bc ;; Context updaters and termination predicate
+                   $absupd $argupd $tmnpred
+                   ;; Updated context for proof abstraction
+                   ($absupd (: ($prfabs $prfarg) $ccln) $ctx)
+                   ;; Proof abstraction query
+                   (: $prfabs (-> $prms $ccln))))
+              ;; Recurse on proof argument
+              ((: $prfarg $prms)
+               (bc ;; Context updaters and termination predicate
+                   $absupd $argupd $tmnpred
+                   ;; Updated context for proof argument
+                   ($argupd (: ($prfabs $prfarg) $ccln) $ctx)
+                   ;; Proof argument query
+                   (: $prfarg $prms))))
+         ;; Post-application termination conditional
+         (if ($tmnpred (: ($prfabs $prfarg) $ccln) $ctx)
+             ;; Terminate by pruning the branch
+             (empty)
+             ;; Continue by returning result
+             (: ($prfabs $prfarg) $ccln)))))
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Common functions ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; Return True iff $lhs unifies with $rhs
+(: ≐ (-> $a $a Bool))
+(= (≐ $lhs $rhs) (case $rhs (($lhs True) ($_ False))))
+
+;; Define Nat
+(: Nat Type)
+(: Z Nat)
+(: S (-> Nat Nat))
+
+;; Define <=
+(: <= (-> $a $a Bool))
+(= (<= $x $y) (or (< $x $y) (== $x $y)))
+
+;; Define cast functions between Nat and Number
+(: fromNumber (-> Number Nat))
+(= (fromNumber $n) (if (<= $n 0) Z (S (fromNumber (- $n 1)))))
+(: fromNat (-> Nat Number))
+(= (fromNat Z) 0)
+(= (fromNat (S $k)) (+ 1 (fromNat $k)))
+
+;; NEXT

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -32,8 +32,6 @@
 ;; Queries and results are contextualized.  For now we rely on a
 ;; concrete implementation instead of an interface.
 
-;; TODO: instead of context, environment might be a good term as well.
-
 ;; Takes a context type, a value type, and create a type representing
 ;; a contextualized value.
 (: CtxVal (-> $ctx $a Type))
@@ -96,7 +94,7 @@
                (bc (MkCtxVal $utx (: $prfabs (-> $prms $ccln))) $ctx_upd $ctx_agg $tmn_pred))
               ;; Recurse on proof argument
               ((MkCtxVal $ctxarg (: $prfarg $prms))
-               (bc (MkCtxVal $utx (: $prfarg $prms) $ctx_upd $ctx_agg $tmn_pred)))
+               (bc (MkCtxVal $utx (: $prfarg $prms)) $ctx_upd $ctx_agg $tmn_pred))
               ;; Merge all contexts so far to form a new context
               ($ntx ($ctx_agg $utx $ctxabs $ctxarg)))
          ;; Build contextualized result
@@ -144,9 +142,19 @@
   ())
 
 ;; Prove A
-;; !(assertEqual
-  !(bc (MkCtxVal (fromNumber 1) (: $prf A)) dec fst is_zero)
-  ;; (MkCtxVal Z (: a A)))
+!(bc (MkCtxVal (fromNumber 1) (: $prf A)) dec fst is_zero)
+
+;; Prove (-> $pq (-> $p B))
+!(bc (MkCtxVal (fromNumber 1) (: $prfabs (-> $pq (-> $p B)))) dec fst is_zero)
+
+;; Prove (-> A B)
+!(bc (MkCtxVal (fromNumber 2) (: ($prfabs $prfarg) (-> $p B))) dec fst is_zero)
 
 ;; Prove B
-  !(bc (MkCtxVal (fromNumber 2) (: $prf B)) dec fst is_zero)
+!(bc (MkCtxVal (fromNumber 3) (: $prf B)) dec fst is_zero)
+
+;; Prove C
+!(bc (MkCtxVal (fromNumber 4) (: $prf C)) dec fst is_zero)
+
+;; Prove C (via deduction as well)
+!(bc (MkCtxVal (fromNumber 5) (: $prf C)) dec fst is_zero)

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -1,3 +1,9 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Inference control experiments.  Modify the backward chainer to take ;;
+;; control functions (context updaters and termination predicate) in   ;;
+;; order to control inference                                          ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Knowledge and Rule Base ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -45,7 +51,7 @@
 ;;   (post-application).  Terminating amounts to pruning the reduction
 ;;   (as in evaluation) branches.  For now there is only one
 ;;   termination predicate for both pre and post application, in the
-;;   future we may want to separate them in two.
+;;   future we may want to separate it in two.
 ;;
 ;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
 ;;   <PROOF> and <THEOREM> may contain free variables that may be

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -1,0 +1,152 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Knowledge and Rule Base ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Similar to the traditional backward chaining DTL but rules are
+;; curried.  This allows to partially apply rule which is useful for
+;; inferring proof abstractions.
+
+;; Knowledge and rule base
+!(bind! &kb (new-space))
+
+;; Knowledge base
+!(add-atom &kb (: ab (→ A B)))
+!(add-atom &kb (: bc (→ B C)))
+!(add-atom &kb (: a A))
+
+;; Rule base
+!(add-atom &kb (: ModusPonens (-> (→ $p $q)  ; Premise 1
+                                  (-> $p     ; Premise 2
+                                      $q)))) ; Conclusion
+!(add-atom &kb (: Deduction (-> (→ $q $r)         ; Premise 1
+                                (-> (→ $p $q)     ; Premise 2
+                                    (→ $p $r))))) ; Conclusion
+!(add-atom &kb (: . (-> (-> $q $r)         ; Premise 1
+                        (-> (-> $p $q)     ; Premise 2
+                            (-> $p $r))))) ; Conclusion
+
+;;;;;;;;;;;;;
+;; Context ;;
+;;;;;;;;;;;;;
+
+;; Queries and results are contextualized.  For now we rely on a
+;; concrete implementation instead of an interface.
+
+;; TODO: instead of context, environment might be a good term as well.
+
+;; Takes a context type, a value type, and create a type representing
+;; a contextualized value.
+(: CtxVal (-> $ctx $a Type))
+
+;; Ctx constructor, takes a context, a value, and construct a
+;; contextualized value.
+(: MkCtxVal (-> $ctx $a (CtxVal $ctx $a)))
+
+;; Access functions
+
+;; Access the context of a contextualized value
+(: CtxVal.context (-> (CtxVal $ctx $a) $ctx))
+(= (CtxVal.context (MkCtxVal $c $x) $c))
+
+;; Access the value of the contextualized value
+(: CtxVal.value (-> (CtxVal $ctx $a) $a))
+(= (CtxVal.value (MkCtx $c $x) $c))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Backward DTL Curried ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Backward Chainer.  The depth is replaced by:
+;;
+;; * Contextualized input and output.
+;; * Context updater and aggregator functions.
+;; * Termination predicate.  Terminating amounts to pruning here.
+;;
+;; The context updater is to update the context from the caller before
+;; the recursive calls.  The context aggregator is to aggregate the
+;; contexts resulting from children calls, as well the updated
+;; context.
+(: bc (-> (CtxVal $ctx $a)         ; Contextualized query
+          (-> $ctx $ctx)           ; Context updater
+          (-> $ctx $ctx $ctx $ctx) ; Context aggregator
+          (-> $ctx Bool)           ; Termination predicate
+          (CtxVal $ctx $a)))       ; Contextualized result
+
+;; Base case.  Terminates no matter what, either by pruning the branch
+;; or by querying the kb.  Thanks to non-determinism, terminating the
+;; branch does not terminate alternative branches.
+(= (bc (MkCtxVal $ctx (: $prf $ccln)) $ctx_upd $ctx_agg $tmn_pred)
+   (if ($tmn_pred $ctx)
+       ;; Terminate by pruning the branch
+       (empty)
+       ;; Terminate by querying the kb
+       (MkCtxVal ($ctx_upd $ctx) (match &kb (: $prf $ccln) (: $prf $ccln)))))
+
+;; Recursive step.  Recursion only happens if termination is
+;; unsatisfied.  If termination is satisfied, the branch is pruned.
+(= (bc (MkCtxVal $ctx (: ($prfabs $prfarg) $ccln)) $ctx_upd $ctx_agg $tmn_pred)
+   (if ($tmn_pred $ctx)
+       ;; Terminate by pruning the branch
+       (empty)
+       ;; Continue
+       (let* (;; Update context to be passed to the recursive calls
+              ($utx ($ctx_upd $ctx))
+              ;; Recurse on proof abstraction
+              ((MkCtxVal $ctxabs (: $prfabs (-> $prms $ccln)))
+               (bc (MkCtxVal $utx (: $prfabs (-> $prms $ccln))) $ctx_upd $ctx_agg $tmn_pred))
+              ;; Recurse on proof argument
+              ((MkCtxVal $ctxarg (: $prfarg $prms))
+               (bc (MkCtxVal $utx (: $prfarg $prms) $ctx_upd $ctx_agg $tmn_pred)))
+              ;; Merge all contexts so far to form a new context
+              ($ntx ($ctx_agg $utx $ctxabs $ctxarg)))
+         ;; Build contextualized result
+         (MkCtxVal $ntx (: ($prfabs $prfarg) $ccln)))))
+
+;;;;;;;;;;
+;; Test ;;
+;;;;;;;;;;
+
+;; The context is a natural number
+
+;; Define Nat
+(: Nat Type)
+(: Z Nat)
+(: S (-> Nat Nat))
+
+;; Define <=
+(: <= (-> $a $a Bool))
+(= (<= $x $y) (or (< $x $y) (== $x $y)))
+
+;; Define cast functions between Nat and Number
+(: fromNumber (-> Number Nat))
+(= (fromNumber $n) (if (<= $n 0) Z (S (fromNumber (- $n 1)))))
+(: fromNat (-> Nat Number))
+(= (fromNat Z) 0)
+(= (fromNat (S $k)) (+ 1 (fromNat $k)))
+
+;; Define context updater, which just decrease a natural
+(: dec (-> Nat Nat))
+(= (dec Z) Z)
+(= (dec (S $k)) $k)
+
+;; Define context aggregator, which just pass the updated context
+(: fst (-> Nat Nat Nat Nat))
+(= (fst $x $y $z) $x)
+
+;; Define termination predicate, which just terminates at zero
+(: is_zero (-> Nat Bool))
+(= (is_zero Z) True)
+(= (is_zero (S $k)) False)
+
+;; Prove nothing, depth of 0 means everything is pruned.
+!(assertEqualToResult
+  (bc (MkCtxVal (fromNumber 0) (: $prf A)) dec fst is_zero)
+  ())
+
+;; Prove A
+;; !(assertEqual
+  !(bc (MkCtxVal (fromNumber 1) (: $prf A)) dec fst is_zero)
+  ;; (MkCtxVal Z (: a A)))
+
+;; Prove B
+  !(bc (MkCtxVal (fromNumber 2) (: $prf B)) dec fst is_zero)

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -25,9 +25,9 @@
                         (-> (-> $p $q)     ; Premise 2
                             (-> $p $r))))) ; Conclusion
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Backward DTL Curried ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Backward Controlled Chainer ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Backward Chainer.  The arguments of the backward chainer are:
 ;;
@@ -40,9 +40,12 @@
 ;;   chainer on the proof argument.
 ;;
 ;; * Termination predicate.  Given the current query and context,
-;;   condition of a conditional wrapping the base case and recursive
-;;   step functions.  Terminating amounts to pruning the reduction (as
-;;   in evaluation) branch.
+;;   provide the condition of a conditional wrapping the base case and
+;;   recursive step functions (pre-application), as well its results
+;;   (post-application).  Terminating amounts to pruning the reduction
+;;   (as in evaluation) branches.  For now there is only one
+;;   termination predicate for both pre and post application, in the
+;;   future we may want to separate them in two.
 ;;
 ;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
 ;;   <PROOF> and <THEOREM> may contain free variables that may be
@@ -70,19 +73,27 @@
 ;; or by querying the kb.  Thanks to non-determinism, terminating the
 ;; branch does not terminate alternative branches.
 (= (bc $absupd $argupd $tmnpred $ctx (: $prf $ccln))
+   ;; Pre-application termination conditional
    (if ($tmnpred (: $prf $ccln) $ctx)
        ;; Terminate by pruning the branch
        (empty)
-       ;; Terminate by querying the kb
-       (match &kb (: $prf $ccln) (: $prf $ccln))))
+       ;; Continue by querying the kb
+       (match &kb (: $prf $ccln)
+              ;; Post-application termination conditional
+              (if ($tmnpred (: $prf $ccln) $ctx)
+                  ;; Terminate by pruning the branch
+                  (empty)
+                  ;; Continue by returning the queried result
+                  (: $prf $ccln)))))
 
 ;; Recursive step.  Recursion only happens if the termination
 ;; condition is false.  Otherwise, the branch is pruned.
 (= (bc $absupd $argupd $tmnpred $ctx (: ($prfabs $prfarg) $ccln))
+   ;; Pre-application termination conditional
    (if ($tmnpred (: ($prfabs $prfarg) $ccln) $ctx)
        ;; Terminate by pruning the branch
        (empty)
-       ;; Continue
+       ;; Continue by recursing
        (let* (;; Recurse on proof abstraction
               ((: $prfabs (-> $prms $ccln))
                (bc ;; Context updaters and termination predicate
@@ -99,8 +110,12 @@
                    ($argupd (: ($prfabs $prfarg) $ccln) $ctx)
                    ;; Proof argument query
                    (: $prfarg $prms))))
-         ;; Construct result
-         (: ($prfabs $prfarg) $ccln))))
+         ;; Post-application termination conditional
+         (if ($tmnpred (: ($prfabs $prfarg) $ccln) $ctx)
+             ;; Terminate by pruning the branch
+             (empty)
+             ;; Continue by returning result
+             (: ($prfabs $prfarg) $ccln)))))
 
 ;;;;;;;;;;;
 ;; Tests ;;
@@ -214,37 +229,115 @@
    (: ((. (ModusPonens bc)) (ModusPonens ab)) (-> A C))
    (: (ModusPonens ((Deduction bc) ab)) (-> A C))))
 
-;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; ;; Context is depth, initial query and current query ;;
-;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Context is depth and initial query ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; ;; From the previous runs we obverse 3 things
-;; ;;
-;; ;; 1. When the queried theorem is (→ x y) then deduction is useful.
-;; ;; 2. When the queried theorem is otherwise then modus ponens is enough.
-;; ;; 3. Composition . is never necessary even for theorem like (-> x y).
-;; ;;
-;; ;; We thus define context and control functions reflecting these observations
+;; From the previous runs we make the following observations:
+;;
+;; 1. When the queried theorem is (→ x y) then modus ponens is useless.
+;;
+;; 2. When the queried theorem is otherwise then deduction is useless.
+;;
+;; 3. Composition . is useless.
+;;
+;; Then we define context and control functions reflecting these
+;; observations.
 
-;; ;; Context type and ctor
-;; (: Ctx Type)
-;; (: MkCtx (-> Nat                    ; Maximum depth
-;;              $iqt                   ; Initial query
-;;              $cqt                   ; Current query
-;;              Ctx))
+;; Context type and ctor
+(: QD Type)
+(: MkDQ (-> $a                     ; Initial query
+            Nat                    ; Maximum depth
+            QD))
 
-;; ;; Define context abstraction updater.  Decrement the depth, leave the
-;; ;; initial query unchangedand current queries unchanged.
-;; (: abs-updater (-> Ctx Ctx))
-;; (= (abs-updater (MkCtx $depth $query (: ($prfabs $prfarg) $ccln)))
-;;    (MkCtx (dec $depth) $query (: $prfabs (-> $prms $ccln)))
+;; Define context updater, same for both proof abstraction and proof
+;; argument.  Decrement the depth, leave the initial query unchanged.
+(: qd-updater (-> $a QD QD))
+(= (qd-updater $query (MkQD $init-query $depth))
+   (MkQD $init-query (dec $depth)))
 
-;; (: $prfabs (-> $prms $ccln))
+;; Define termination predicate.  Terminate at depth 0, and respect
+;; the 3 observations above.
+(: qd-termination (-> $a QD Bool))
+(= (qd-termination (: $prf $thm) (MkQD (: $init-prf $init-thm) $depth))
+   (or ;; Terminate at depth 0
+       (is-zero $depth)
+       ;; [3th observation] If the current proof query is . then
+       ;; terminate.
+       (or (== $prf .)
+           ;; [1st observation] If initial queried theorem is (→ x y)
+           ;; and current proof query is not Deduction (thus is
+           ;; ModusPonens, as it is the only alternative at this
+           ;; point), then terminate.
+           (if (== $init-thm (→ $x $y))
+               (== $prf ModusPonens)
+               ;; [2nd observation] Otherwise, if the current proof
+               ;; query is not ModusPonens (thus Deduction, as it is
+               ;; the only alternative at this point), then terminate.
+               (== $prf Deduction)))))
 
-;; ;; Define termination predicate.  Terminates at 0 and make sure to
-;; ;; respect the 3 observations above.  NEXT.
-;; (: terminate (-> Ctx Bool))
-;; (= (terminate (MkCtx $depth $iniqry $curqry))
-;;    (or (is-zero $depth)
-       
-;;        ))
+;; Prove nothing, depth of 0 means everything is pruned.
+!(assertEqualToResult
+  (bc qd-updater qd-updater qd-termination ; Updaters and termination predicate
+      (MkQD (: $prf A) (fromNumber 0))     ; Context
+      (: $prf A))                          ; Query
+  ())
+
+;; Prove A
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prf A) (fromNumber 2))
+      (: $prf A))
+  (: a A))
+
+;; Prove (-> (→ $p B) (-> $p B))
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prfabs (-> $pq (-> $p B))) (fromNumber 2))
+      (: $prfabs (-> $pq (-> $p B))))
+  (: ModusPonens (-> (→ $p B) (-> $p B))))
+
+;; Prove (-> A B)
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: ($prfabs $prfarg) (-> $p B)) (fromNumber 2))
+      (: ($prfabs $prfarg) (-> $p B)))
+  (: (ModusPonens ab) (-> A B)))
+
+;; Prove B
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prf B) (fromNumber 3))
+      (: $prf B))
+  (: ((ModusPonens ab) a) B))
+
+;; Prove C
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prf C) (fromNumber 4))
+      (: $prf C))
+  (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
+
+;; Prove C (deduction is discarded via inference control)
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prf C) (fromNumber 5))
+      (: $prf C))
+  (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
+
+;; Prove (→ A C)
+;; NEXT
+!(assertEqual
+  (bc qd-updater qd-updater qd-termination
+      (MkQD (: $prf (→ A C)) (fromNumber 4))
+      (: $prf (→ A C)))
+  (: ((Deduction bc) ab) (→ A C)))
+
+;; ;; Prove (-> A C).  Inference control prevents from finding a proof
+;; ;; because any of the proofs involve using Deduction, or ., which are
+;; ;; both forbidden for that query.
+;; !(assertEqualToResult
+;;   (bc qd-updater qd-updater qd-termination
+;;       (MkQD (: $prf (-> A C)) (fromNumber 4))
+;;       (: $prf (-> A C)))
+;;   ())

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -31,15 +31,18 @@
 
 ;; Backward Chainer.  The arguments of the backward chainer are:
 ;;
-;; * Context abstraction updater.  Update the context before
-;;   recursively calling the backward chainer on the proof abstraction.
+;; * Context abstraction updater.  Given the current query and
+;;   context, update the context before recursively calling the
+;;   backward chainer on the proof abstraction.
 ;;
-;; * Context argument updater.  Update the context before recursively
-;;   calling the backward chainer on the proof argument.
+;; * Context argument updater.  Given the current query and context,
+;;   update the context before recursively calling the backward
+;;   chainer on the proof argument.
 ;;
-;; * Termination predicate.  Condition of a conditional wrapping the
-;;   base case and recursive step functions.  Terminating amounts to
-;;   pruning the reduction (as in evaluation) branch.
+;; * Termination predicate.  Given the current query and context,
+;;   condition of a conditional wrapping the base case and recursive
+;;   step functions.  Terminating amounts to pruning the reduction (as
+;;   in evaluation) branch.
 ;;
 ;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
 ;;   <PROOF> and <THEOREM> may contain free variables that may be
@@ -48,29 +51,26 @@
 ;; * Context: a context to be updated and passed to the recursive
 ;;   calls of the backward chainer.
 ;;
-;; The context updater is to update the context from the caller before
-;; the recursive calls.  The context aggregator is to aggregate the
-;; contexts resulting from children calls, as well the updated
-;; context.
-;;
-;; NEXT: maybe the context updaters and the termination predicate
-;; should take the query as well.  It could also take a contextualized
-;; query, but it's probably not a good idea to return a contextualized
-;; query because we don't want the user to be able to modify the
-;; query, as it could lead to breaking the backward chainer, as
-;; opposed to just pruning its search.
-(: bc (-> (-> $ct $ct)      ; Context abstraction updater
-          (-> $ct $ct)      ; Context argument updater
-          (-> $ct Bool)     ; Termination predicate
-          $ct               ; Context
-          $a                ; Query
-          $a))              ; Query result
+;; The choice of the arguments of the context updaters and the
+;; termination predicate is justified as follows.  Context updaters
+;; take first the query, which can be viewed an updater modulator,
+;; which then takes the actual context to the return updated one.  An
+;; alternative would have been to construct a contextualized query,
+;; and update that contextualized query instead.  However, we do not
+;; do that to guaranty that the user-programmed inference control does
+;; not interfere with the correctness of the chainer.
+(: bc (-> (-> $a $ct $ct)      ; Context abstraction updater
+          (-> $a $ct $ct)      ; Context argument updater
+          (-> $a $ct Bool)     ; Termination predicate
+          $ct                  ; Context
+          $a                   ; Query
+          $a))                 ; Query result
 
 ;; Base case.  Terminates no matter what, either by pruning the branch
 ;; or by querying the kb.  Thanks to non-determinism, terminating the
 ;; branch does not terminate alternative branches.
 (= (bc $absupd $argupd $tmnpred $ctx (: $prf $ccln))
-   (if ($tmnpred $ctx)
+   (if ($tmnpred (: $prf $ccln) $ctx)
        ;; Terminate by pruning the branch
        (empty)
        ;; Terminate by querying the kb
@@ -79,7 +79,7 @@
 ;; Recursive step.  Recursion only happens if the termination
 ;; condition is false.  Otherwise, the branch is pruned.
 (= (bc $absupd $argupd $tmnpred $ctx (: ($prfabs $prfarg) $ccln))
-   (if ($tmnpred $ctx)
+   (if ($tmnpred (: ($prfabs $prfarg) $ccln) $ctx)
        ;; Terminate by pruning the branch
        (empty)
        ;; Continue
@@ -88,7 +88,7 @@
                (bc ;; Context updaters and termination predicate
                    $absupd $argupd $tmnpred
                    ;; Updated context for proof abstraction
-                   ($absupd $ctx)
+                   ($absupd (: ($prfabs $prfarg) $ccln) $ctx)
                    ;; Proof abstraction query
                    (: $prfabs (-> $prms $ccln))))
               ;; Recurse on proof argument
@@ -96,7 +96,7 @@
                (bc ;; Context updaters and termination predicate
                    $absupd $argupd $tmnpred
                    ;; Updated context for proof argument
-                   ($argupd $ctx)
+                   ($argupd (: ($prfabs $prfarg) $ccln) $ctx)
                    ;; Proof argument query
                    (: $prfarg $prms))))
          ;; Construct result
@@ -135,41 +135,84 @@
 (: dec (-> Nat Nat))
 (= (dec Z) Z)
 (= (dec (S $k)) $k)
+(: depth-updater (-> $a Nat Nat))
+(= (depth-updater $query $depth) (dec $depth))
 
 ;; Define termination predicate, called inside a conditional wrapping
 ;; the bc.  Terminates at 0.
 (: is-zero (-> Nat Bool))
 (= (is-zero Z) True)
 (= (is-zero (S $k)) False)
+(: depth-termination (-> $a Nat Bool))
+(= (depth-termination $query $depth) (is-zero $depth))
 
 ;; Prove nothing, depth of 0 means everything is pruned.
 !(assertEqualToResult
-  (bc dec dec is-zero (fromNumber 0) (: $prf A))
+  (bc depth-updater depth-updater depth-termination ; Updaters and termination predicate
+      (fromNumber 0)                                ; Context
+      (: $prf A))                                   ; Query
   ())
 
 ;; Prove A
-!(bc dec dec is-zero (fromNumber 1) (: $prf A))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 2)
+      (: $prf A))
+  (: a A))
 
 ;; Prove (-> (→ $p B) (-> $p B))
-!(bc dec dec is-zero (fromNumber 1) (: $prfabs (-> $pq (-> $p B))))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 2)
+      (: $prfabs (-> $pq (-> $p B))))
+  (: ModusPonens (-> (→ $p B) (-> $p B))))
 
 ;; Prove (-> A B)
-!(bc dec dec is-zero (fromNumber 2) (: ($prfabs $prfarg) (-> $p B)))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 2)
+      (: ($prfabs $prfarg) (-> $p B)))
+  (: (ModusPonens ab) (-> A B)))
 
 ;; Prove B
-!(bc dec dec is-zero (fromNumber 3) (: $prf B))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 3)
+      (: $prf B))
+  (: ((ModusPonens ab) a) B))
 
 ;; Prove C
-!(bc dec dec is-zero (fromNumber 4) (: $prf C))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 4)
+      (: $prf C))
+  (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
 
 ;; Prove C (via deduction as well)
-!(bc dec dec is-zero (fromNumber 5) (: $prf C))
+!(assertEqualToResult
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 5)
+      (: $prf C))
+  ((: ((((. ModusPonens) (Deduction bc)) ab) a) C)
+   (: (((. (ModusPonens bc)) (ModusPonens ab)) a) C)
+   (: ((ModusPonens ((Deduction bc) ab)) a) C)
+   (: ((ModusPonens bc) ((ModusPonens ab) a)) C)))
 
 ;; Prove (→ A C)
-!(bc dec dec is-zero (fromNumber 4) (: $prf (→ A C)))
+!(assertEqual
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 4)
+      (: $prf (→ A C)))
+  (: ((Deduction bc) ab) (→ A C)))
 
 ;; Prove (-> A C)
-!(bc dec dec is-zero (fromNumber 4) (: $prf (-> A C)))
+!(assertEqualToResult
+  (bc depth-updater depth-updater depth-termination
+      (fromNumber 4)
+      (: $prf (-> A C)))
+  ((: (((. ModusPonens) (Deduction bc)) ab) (-> A C))
+   (: ((. (ModusPonens bc)) (ModusPonens ab)) (-> A C))
+   (: (ModusPonens ((Deduction bc) ab)) (-> A C))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ;; Context is depth, initial query and current query ;;

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -25,86 +25,86 @@
                         (-> (-> $p $q)     ; Premise 2
                             (-> $p $r))))) ; Conclusion
 
-;;;;;;;;;;;;;
-;; Context ;;
-;;;;;;;;;;;;;
-
-;; Queries and results are contextualized.  For now we rely on a
-;; concrete implementation instead of an interface.
-
-;; Takes a context type, a value type, and create a type representing
-;; a contextualized value.
-(: CtxVal (-> $ctx $a Type))
-
-;; Ctx constructor, takes a context, a value, and construct a
-;; contextualized value.
-(: MkCtxVal (-> $ctx $a (CtxVal $ctx $a)))
-
-;; Access functions
-
-;; Access the context of a contextualized value
-(: CtxVal.context (-> (CtxVal $ctx $a) $ctx))
-(= (CtxVal.context (MkCtxVal $c $x) $c))
-
-;; Access the value of the contextualized value
-(: CtxVal.value (-> (CtxVal $ctx $a) $a))
-(= (CtxVal.value (MkCtx $c $x) $c))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Backward DTL Curried ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Backward Chainer.  The depth is replaced by:
+;; Backward Chainer.  The arguments of the backward chainer are:
 ;;
-;; * Contextualized input and output.
-;; * Context updater and aggregator functions.
-;; * Termination predicate.  Terminating amounts to pruning here.
+;; * Context abstraction updater.  Update the context before
+;;   recursively calling the backward chainer on the proof abstraction.
+;;
+;; * Context argument updater.  Update the context before recursively
+;;   calling the backward chainer on the proof argument.
+;;
+;; * Termination predicate.  Condition of a conditional wrapping the
+;;   base case and recursive step functions.  Terminating amounts to
+;;   pruning the reduction (as in evaluation) branch.
+;;
+;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables that may be
+;;   filled by the backward chainer.
+;;
+;; * Context: a context to be updated and passed to the recursive
+;;   calls of the backward chainer.
 ;;
 ;; The context updater is to update the context from the caller before
 ;; the recursive calls.  The context aggregator is to aggregate the
 ;; contexts resulting from children calls, as well the updated
 ;; context.
-(: bc (-> (CtxVal $ctx $a)         ; Contextualized query
-          (-> $ctx $ctx)           ; Context updater
-          (-> $ctx $ctx $ctx $ctx) ; Context aggregator
-          (-> $ctx Bool)           ; Termination predicate
-          (CtxVal $ctx $a)))       ; Contextualized result
+;;
+;; NEXT: maybe the context updaters and the termination predicate
+;; should take the query as well.  It could also take a contextualized
+;; query, but it's probably not a good idea to return a contextualized
+;; query because we don't want the user to be able to modify the
+;; query, as it could lead to breaking the backward chainer, as
+;; opposed to just pruning its search.
+(: bc (-> (-> $ct $ct)      ; Context abstraction updater
+          (-> $ct $ct)      ; Context argument updater
+          (-> $ct Bool)     ; Termination predicate
+          $ct               ; Context
+          $a                ; Query
+          $a))              ; Query result
 
 ;; Base case.  Terminates no matter what, either by pruning the branch
 ;; or by querying the kb.  Thanks to non-determinism, terminating the
 ;; branch does not terminate alternative branches.
-(= (bc (MkCtxVal $ctx (: $prf $ccln)) $ctx_upd $ctx_agg $tmn_pred)
-   (if ($tmn_pred $ctx)
+(= (bc $absupd $argupd $tmnpred $ctx (: $prf $ccln))
+   (if ($tmnpred $ctx)
        ;; Terminate by pruning the branch
        (empty)
        ;; Terminate by querying the kb
-       (MkCtxVal ($ctx_upd $ctx) (match &kb (: $prf $ccln) (: $prf $ccln)))))
+       (match &kb (: $prf $ccln) (: $prf $ccln))))
 
-;; Recursive step.  Recursion only happens if termination is
-;; unsatisfied.  If termination is satisfied, the branch is pruned.
-(= (bc (MkCtxVal $ctx (: ($prfabs $prfarg) $ccln)) $ctx_upd $ctx_agg $tmn_pred)
-   (if ($tmn_pred $ctx)
+;; Recursive step.  Recursion only happens if the termination
+;; condition is false.  Otherwise, the branch is pruned.
+(= (bc $absupd $argupd $tmnpred $ctx (: ($prfabs $prfarg) $ccln))
+   (if ($tmnpred $ctx)
        ;; Terminate by pruning the branch
        (empty)
        ;; Continue
-       (let* (;; Update context to be passed to the recursive calls
-              ($utx ($ctx_upd $ctx))
-              ;; Recurse on proof abstraction
-              ((MkCtxVal $ctxabs (: $prfabs (-> $prms $ccln)))
-               (bc (MkCtxVal $utx (: $prfabs (-> $prms $ccln))) $ctx_upd $ctx_agg $tmn_pred))
+       (let* (;; Recurse on proof abstraction
+              ((: $prfabs (-> $prms $ccln))
+               (bc ;; Context updaters and termination predicate
+                   $absupd $argupd $tmnpred
+                   ;; Updated context for proof abstraction
+                   ($absupd $ctx)
+                   ;; Proof abstraction query
+                   (: $prfabs (-> $prms $ccln))))
               ;; Recurse on proof argument
-              ((MkCtxVal $ctxarg (: $prfarg $prms))
-               (bc (MkCtxVal $utx (: $prfarg $prms)) $ctx_upd $ctx_agg $tmn_pred))
-              ;; Merge all contexts so far to form a new context
-              ($ntx ($ctx_agg $utx $ctxabs $ctxarg)))
-         ;; Build contextualized result
-         (MkCtxVal $ntx (: ($prfabs $prfarg) $ccln)))))
+              ((: $prfarg $prms)
+               (bc ;; Context updaters and termination predicate
+                   $absupd $argupd $tmnpred
+                   ;; Updated context for proof argument
+                   ($argupd $ctx)
+                   ;; Proof argument query
+                   (: $prfarg $prms))))
+         ;; Construct result
+         (: ($prfabs $prfarg) $ccln))))
 
-;;;;;;;;;;
-;; Test ;;
-;;;;;;;;;;
-
-;; The context is a natural number
+;;;;;;;;;;;
+;; Tests ;;
+;;;;;;;;;;;
 
 ;; Define Nat
 (: Nat Type)
@@ -122,39 +122,86 @@
 (= (fromNat Z) 0)
 (= (fromNat (S $k)) (+ 1 (fromNat $k)))
 
-;; Define context updater, which just decrease a natural
+;;;;;;;;;;;;;;;;;;;;;;
+;; Context is depth ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; The context is the maximum depth, thus reproduces the experiments
+;; done so far.  Note that a depth of 1, not 0, allows to query the
+;; KB.
+
+;; Define context updater, same for both for proof abstraction and
+;; argument.  Decrement the depth.
 (: dec (-> Nat Nat))
 (= (dec Z) Z)
 (= (dec (S $k)) $k)
 
-;; Define context aggregator, which just pass the updated context
-(: fst (-> Nat Nat Nat Nat))
-(= (fst $x $y $z) $x)
-
-;; Define termination predicate, which just terminates at zero
-(: is_zero (-> Nat Bool))
-(= (is_zero Z) True)
-(= (is_zero (S $k)) False)
+;; Define termination predicate, called inside a conditional wrapping
+;; the bc.  Terminates at 0.
+(: is-zero (-> Nat Bool))
+(= (is-zero Z) True)
+(= (is-zero (S $k)) False)
 
 ;; Prove nothing, depth of 0 means everything is pruned.
 !(assertEqualToResult
-  (bc (MkCtxVal (fromNumber 0) (: $prf A)) dec fst is_zero)
+  (bc dec dec is-zero (fromNumber 0) (: $prf A))
   ())
 
 ;; Prove A
-!(bc (MkCtxVal (fromNumber 1) (: $prf A)) dec fst is_zero)
+!(bc dec dec is-zero (fromNumber 1) (: $prf A))
 
-;; Prove (-> $pq (-> $p B))
-!(bc (MkCtxVal (fromNumber 1) (: $prfabs (-> $pq (-> $p B)))) dec fst is_zero)
+;; Prove (-> (→ $p B) (-> $p B))
+!(bc dec dec is-zero (fromNumber 1) (: $prfabs (-> $pq (-> $p B))))
 
 ;; Prove (-> A B)
-!(bc (MkCtxVal (fromNumber 2) (: ($prfabs $prfarg) (-> $p B))) dec fst is_zero)
+!(bc dec dec is-zero (fromNumber 2) (: ($prfabs $prfarg) (-> $p B)))
 
 ;; Prove B
-!(bc (MkCtxVal (fromNumber 3) (: $prf B)) dec fst is_zero)
+!(bc dec dec is-zero (fromNumber 3) (: $prf B))
 
 ;; Prove C
-!(bc (MkCtxVal (fromNumber 4) (: $prf C)) dec fst is_zero)
+!(bc dec dec is-zero (fromNumber 4) (: $prf C))
 
 ;; Prove C (via deduction as well)
-!(bc (MkCtxVal (fromNumber 5) (: $prf C)) dec fst is_zero)
+!(bc dec dec is-zero (fromNumber 5) (: $prf C))
+
+;; Prove (→ A C)
+!(bc dec dec is-zero (fromNumber 4) (: $prf (→ A C)))
+
+;; Prove (-> A C)
+!(bc dec dec is-zero (fromNumber 4) (: $prf (-> A C)))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; ;; Context is depth, initial query and current query ;;
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; ;; From the previous runs we obverse 3 things
+;; ;;
+;; ;; 1. When the queried theorem is (→ x y) then deduction is useful.
+;; ;; 2. When the queried theorem is otherwise then modus ponens is enough.
+;; ;; 3. Composition . is never necessary even for theorem like (-> x y).
+;; ;;
+;; ;; We thus define context and control functions reflecting these observations
+
+;; ;; Context type and ctor
+;; (: Ctx Type)
+;; (: MkCtx (-> Nat                    ; Maximum depth
+;;              $iqt                   ; Initial query
+;;              $cqt                   ; Current query
+;;              Ctx))
+
+;; ;; Define context abstraction updater.  Decrement the depth, leave the
+;; ;; initial query unchangedand current queries unchanged.
+;; (: abs-updater (-> Ctx Ctx))
+;; (= (abs-updater (MkCtx $depth $query (: ($prfabs $prfarg) $ccln)))
+;;    (MkCtx (dec $depth) $query (: $prfabs (-> $prms $ccln)))
+
+;; (: $prfabs (-> $prms $ccln))
+
+;; ;; Define termination predicate.  Terminates at 0 and make sure to
+;; ;; respect the 3 observations above.  NEXT.
+;; (: terminate (-> Ctx Bool))
+;; (= (terminate (MkCtx $depth $iniqry $curqry))
+;;    (or (is-zero $depth)
+       
+;;        ))

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -117,9 +117,13 @@
              ;; Continue by returning result
              (: ($prfabs $prfarg) $ccln)))))
 
-;;;;;;;;;;;
-;; Tests ;;
-;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;
+;; Common functions ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; Return True iff $lhs unifies with $rhs
+(: ≐ (-> $a $a Bool))
+(= (≐ $lhs $rhs) (case $rhs (($lhs True) ($_ False))))
 
 ;; Define Nat
 (: Nat Type)
@@ -136,6 +140,10 @@
 (: fromNat (-> Nat Number))
 (= (fromNat Z) 0)
 (= (fromNat (S $k)) (+ 1 (fromNat $k)))
+
+;;;;;;;;;;;
+;; Tests ;;
+;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Context is depth ;;
@@ -158,54 +166,54 @@
 (: is-zero (-> Nat Bool))
 (= (is-zero Z) True)
 (= (is-zero (S $k)) False)
-(: depth-termination (-> $a Nat Bool))
-(= (depth-termination $query $depth) (is-zero $depth))
+(: depth-terminator (-> $a Nat Bool))
+(= (depth-terminator $query $depth) (is-zero $depth))
 
 ;; Prove nothing, depth of 0 means everything is pruned.
 !(assertEqualToResult
-  (bc depth-updater depth-updater depth-termination ; Updaters and termination predicate
-      (fromNumber 0)                                ; Context
-      (: $prf A))                                   ; Query
+  (bc depth-updater depth-updater depth-terminator ; Updaters and termination predicate
+      (fromNumber 0)                               ; Context
+      (: $prf A))                                  ; Query
   ())
 
 ;; Prove A
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 2)
       (: $prf A))
   (: a A))
 
 ;; Prove (-> (→ $p B) (-> $p B))
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 2)
       (: $prfabs (-> $pq (-> $p B))))
   (: ModusPonens (-> (→ $p B) (-> $p B))))
 
 ;; Prove (-> A B)
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 2)
       (: ($prfabs $prfarg) (-> $p B)))
   (: (ModusPonens ab) (-> A B)))
 
 ;; Prove B
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 3)
       (: $prf B))
   (: ((ModusPonens ab) a) B))
 
 ;; Prove C
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 4)
       (: $prf C))
   (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
 
 ;; Prove C (via deduction as well)
 !(assertEqualToResult
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 5)
       (: $prf C))
   ((: ((((. ModusPonens) (Deduction bc)) ab) a) C)
@@ -215,14 +223,14 @@
 
 ;; Prove (→ A C)
 !(assertEqual
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 4)
       (: $prf (→ A C)))
   (: ((Deduction bc) ab) (→ A C)))
 
 ;; Prove (-> A C)
 !(assertEqualToResult
-  (bc depth-updater depth-updater depth-termination
+  (bc depth-updater depth-updater depth-terminator
       (fromNumber 4)
       (: $prf (-> A C)))
   ((: (((. ModusPonens) (Deduction bc)) ab) (-> A C))
@@ -245,31 +253,31 @@
 ;; observations.
 
 ;; Context type and ctor
-(: QD Type)
-(: MkDQ (-> $a                     ; Initial query
+(: TD Type)
+(: MkTD (-> $a                     ; Target theorem
             Nat                    ; Maximum depth
-            QD))
+            TD))
 
 ;; Define context updater, same for both proof abstraction and proof
 ;; argument.  Decrement the depth, leave the initial query unchanged.
-(: qd-updater (-> $a QD QD))
-(= (qd-updater $query (MkQD $init-query $depth))
-   (MkQD $init-query (dec $depth)))
+(: td-updater (-> $a TD TD))
+(= (td-updater $query (MkTD $trg-thm $depth))
+   (MkTD $trg-thm (dec $depth)))
 
 ;; Define termination predicate.  Terminate at depth 0, and respect
 ;; the 3 observations above.
-(: qd-termination (-> $a QD Bool))
-(= (qd-termination (: $prf $thm) (MkQD (: $init-prf $init-thm) $depth))
+(: td-terminator (-> $a TD Bool))
+(= (td-terminator (: $prf $thm) (MkTD $trg-thm $depth))
    (or ;; Terminate at depth 0
        (is-zero $depth)
        ;; [3th observation] If the current proof query is . then
        ;; terminate.
        (or (== $prf .)
-           ;; [1st observation] If initial queried theorem is (→ x y)
-           ;; and current proof query is not Deduction (thus is
+           ;; [1st observation] If the target theorem unifies with (→ x y) and
+           ;; current proof query is not Deduction (thus is
            ;; ModusPonens, as it is the only alternative at this
            ;; point), then terminate.
-           (if (== $init-thm (→ $x $y))
+           (if (≐ $trg-thm (→ $x $y))
                (== $prf ModusPonens)
                ;; [2nd observation] Otherwise, if the current proof
                ;; query is not ModusPonens (thus Deduction, as it is
@@ -278,66 +286,65 @@
 
 ;; Prove nothing, depth of 0 means everything is pruned.
 !(assertEqualToResult
-  (bc qd-updater qd-updater qd-termination ; Updaters and termination predicate
-      (MkQD (: $prf A) (fromNumber 0))     ; Context
-      (: $prf A))                          ; Query
+  (bc td-updater td-updater td-terminator ; Updaters and termination predicate
+      (MkTD A (fromNumber 0))             ; Context
+      (: $prf A))                         ; Query
   ())
 
 ;; Prove A
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prf A) (fromNumber 2))
+  (bc td-updater td-updater td-terminator
+      (MkTD A (fromNumber 2))
       (: $prf A))
   (: a A))
 
 ;; Prove (-> (→ $p B) (-> $p B))
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prfabs (-> $pq (-> $p B))) (fromNumber 2))
+  (bc td-updater td-updater td-terminator
+      (MkTD (-> $pq (-> $p B)) (fromNumber 2))
       (: $prfabs (-> $pq (-> $p B))))
   (: ModusPonens (-> (→ $p B) (-> $p B))))
 
 ;; Prove (-> A B)
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: ($prfabs $prfarg) (-> $p B)) (fromNumber 2))
+  (bc td-updater td-updater td-terminator
+      (MkTD (-> $p B) (fromNumber 2))
       (: ($prfabs $prfarg) (-> $p B)))
   (: (ModusPonens ab) (-> A B)))
 
 ;; Prove B
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prf B) (fromNumber 3))
+  (bc td-updater td-updater td-terminator
+      (MkTD B (fromNumber 3))
       (: $prf B))
   (: ((ModusPonens ab) a) B))
 
 ;; Prove C
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prf C) (fromNumber 4))
+  (bc td-updater td-updater td-terminator
+      (MkTD C (fromNumber 4))
       (: $prf C))
   (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
 
 ;; Prove C (deduction is discarded via inference control)
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prf C) (fromNumber 5))
+  (bc td-updater td-updater td-terminator
+      (MkTD C (fromNumber 5))
       (: $prf C))
   (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
 
 ;; Prove (→ A C)
-;; NEXT
 !(assertEqual
-  (bc qd-updater qd-updater qd-termination
-      (MkQD (: $prf (→ A C)) (fromNumber 4))
+  (bc td-updater td-updater td-terminator
+      (MkTD (→ A C) (fromNumber 4))
       (: $prf (→ A C)))
   (: ((Deduction bc) ab) (→ A C)))
 
-;; ;; Prove (-> A C).  Inference control prevents from finding a proof
-;; ;; because any of the proofs involve using Deduction, or ., which are
-;; ;; both forbidden for that query.
-;; !(assertEqualToResult
-;;   (bc qd-updater qd-updater qd-termination
-;;       (MkQD (: $prf (-> A C)) (fromNumber 4))
-;;       (: $prf (-> A C)))
-;;   ())
+;; Prove (-> A C).  Inference control actually prevents from finding a
+;; proof because any of the proofs use either Deduction or ., which
+;; are both forbidden for that query.
+!(assertEqualToResult
+  (bc td-updater td-updater td-terminator
+      (MkTD (-> A C) (fromNumber 0))
+      (: $prf (-> A C)))
+  ())

--- a/metta/inference-control/inf-ctl-xp.metta
+++ b/metta/inference-control/inf-ctl-xp.metta
@@ -243,9 +243,9 @@
    (: ((. (ModusPonens bc)) (ModusPonens ab)) (-> A C))
    (: (ModusPonens ((Deduction bc) ab)) (-> A C))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Context is depth and initial query ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Context is depth and target theorem ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; From the previous runs we make the following observations:
 ;;
@@ -265,7 +265,7 @@
             TD))
 
 ;; Define context updater, same for both proof abstraction and proof
-;; argument.  Decrement the depth, leave the initial query unchanged.
+;; argument.  Decrement the depth, leave the target theorem unchanged.
 (: td-updater (-> $a TD TD))
 (= (td-updater $query (MkTD $trg-thm $depth))
    (MkTD $trg-thm (dec $depth)))


### PR DESCRIPTION
Define backward chainer with context updater functions and termination predicates.

Inference control is user programmable, simple examples, including some resulting in real time speed-ups are provided as well.