### PR TITLE
Draw fully annotated proof tree

### DIFF
--- a/metta/curried-chaining/curried-chainer.metta
+++ b/metta/curried-chaining/curried-chainer.metta
@@ -58,7 +58,9 @@
 ;;
 ;; * Maximum depth: maximum depth of the generated proof tree.
 ;;
-;; Results are returned as a superposition.
+;; A result is the query with its variables grounded, fully or
+;; partially.  If multiple results are possible, they are returned as
+;; a superposition.
 (: bc (-> $a                            ; Knowledge base space
           $b                            ; Query
           Nat                           ; Maximum depth
@@ -102,12 +104,14 @@
 ;;
 ;; * Maximum depth: maximum depth of the generated proof tree.
 ;;
-;; Results are returned as a superposition.
+;; A result is a conclusion that can be reached from the source.  If
+;; multiple results are possible, they are returned as a
+;; superposition.
 (: fc (-> $a                            ; Knowledge base space
           $b                            ; Source
           Nat                           ; Maximum depth
           $b))                          ; Conclusion
-;; Base case.  Beware that the provided source is assumed to be true.
+;; Base case
 (= (fc $kb (: $prf $prms) $_) (: $prf $prms))
 ;; Recursive step
 (= (fc $kb (: $prfarg $prms) (S $k))

--- a/metta/curried-chaining/curried-chainer.metta
+++ b/metta/curried-chaining/curried-chainer.metta
@@ -33,6 +33,7 @@
 
 !(add-atom &kb (: a A))
 !(add-atom &kb (: ab (→ A B)))
+!(add-atom &kb (: bc (→ B C)))
 !(add-atom &kb (: ModusPonens
                 (-> (→ $p $q)
                     (-> $p
@@ -42,55 +43,92 @@
 ;; Backward chainer ;;
 ;;;;;;;;;;;;;;;;;;;;;;
 
-;; Curried Backward Chainer
-(: bc (-> $a Nat $a))
+;; Curried Backward Chainer.  The arguments of the backward chainer
+;; are:
+;;
+;; * Knowledge base: pointer to a space containing axioms and rules in
+;;   the format (: <NAME> <RULE>).  Note that rules are explicitely
+;;   curried, meaning that a rule with two premises is represented by
+;;
+;;   (: <NAME> (-> <PREMISE1> (-> <PREMISE2> <CONCLUSION>)))
+;;
+;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables that may be
+;;   filled by the backward chainer.
+;;
+;; * Maximum depth: maximum depth of the generated proof tree.
+;;
+;; Results are returned as a superposition.
+(: bc (-> $a                            ; Knowledge base space
+          $b                            ; Query
+          Nat                           ; Maximum depth
+          $b))                          ; Result
 ;; Base case
-(= (bc (: $prf $ccln) $_) (match &kb (: $prf $ccln) (: $prf $ccln)))
+(= (bc $kb (: $prf $ccln) $_) (match $kb (: $prf $ccln) (: $prf $ccln)))
 ;; Recursive step
-(= (bc (: ($prfabs $prfarg) $ccln) (S $k))
-   (let* (((: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k))
-          ((: $prfarg $prms) (bc (: $prfarg $prms) $k)))
+(= (bc $kb (: ($prfabs $prfarg) $ccln) (S $k))
+   (let* (((: $prfabs (-> $prms $ccln)) (bc $kb (: $prfabs (-> $prms $ccln)) $k))
+          ((: $prfarg $prms) (bc $kb (: $prfarg $prms) $k)))
      (: ($prfabs $prfarg) $ccln)))
+
+;; Test curred backward chainer
+!(assertEqual
+  (bc &kb (: $prf A) (fromNumber 0))
+  (: a A))
+!(assertEqual
+  (bc &kb (: $prf B) (fromNumber 2))
+  (: ((ModusPonens ab) a) B))
+!(assertEqual
+  (bc &kb (: $prf C) (fromNumber 3))
+  (: ((ModusPonens bc) ((ModusPonens ab) a)) C))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Forward chainer ;;
 ;;;;;;;;;;;;;;;;;;;;;
 
-;; Curried Forward Chainer
-(: fc (-> $a Nat $a))
+;; Curried Forward Chainer.  The arguments of the forward chainer are:
+;;
+;; * Knowledge base: pointer to a space containing axioms and rules in
+;;   the format (: <NAME> <RULE>).  Note that rules are explicitely
+;;   curried, meaning that a rule with two premises is represented by
+;;
+;;   (: <NAME> (-> <PREMISE1> (-> <PREMISE2> <CONCLUSION>)))
+;;
+;; * Source: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables.  Beware that
+;;   the source is assumed to be true.  That is especially important
+;;   to consider when introducing free variables, because these free
+;;   variables will be treated as if they are univerally quantified.
+;;
+;; * Maximum depth: maximum depth of the generated proof tree.
+;;
+;; Results are returned as a superposition.
+(: fc (-> $a                            ; Knowledge base space
+          $b                            ; Source
+          Nat                           ; Maximum depth
+          $b))                          ; Conclusion
 ;; Base case.  Beware that the provided source is assumed to be true.
-(= (fc (: $prf $prms) $_) (: $prf $prms))
+(= (fc $kb (: $prf $prms) $_) (: $prf $prms))
 ;; Recursive step
-(= (fc (: $prfarg $prms) (S $k))
-   (let (: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k)
-     (fc (: ($prfabs $prfarg) $ccln) $k)))
-(= (fc (: $prfabs (-> $prms $ccln)) (S $k))
-    (let (: $prfarg $prms) (bc (: $prfarg $prms) $k)
-     (fc (: ($prfabs $prfarg) $ccln) $k)))
-
-;;;;;;;;;;;
-;; Tests ;;
-;;;;;;;;;;;
-
-;; Test curred backward chainer
-!(assertEqual
-  (bc (: $prf A) (fromNumber 0))
-  (: a A))
-!(assertEqual
-  (bc (: $prf B) (fromNumber 2))
-  (: ((ModusPonens ab) a) B))
+(= (fc $kb (: $prfarg $prms) (S $k))
+   (let (: $prfabs (-> $prms $ccln)) (bc $kb (: $prfabs (-> $prms $ccln)) $k)
+     (fc $kb (: ($prfabs $prfarg) $ccln) $k)))
+(= (fc $kb (: $prfabs (-> $prms $ccln)) (S $k))
+    (let (: $prfarg $prms) (bc $kb (: $prfarg $prms) $k)
+     (fc $kb (: ($prfabs $prfarg) $ccln) $k)))
 
 ;; Test curried forward chainer
 !(assertEqualToResult
-  (fc (: ab (→ A B)) (fromNumber 1))
+  (fc &kb (: ab (→ A B)) (fromNumber 1))
   ((: ab (→ A B))
    (: (ModusPonens ab) (-> A B))))
 !(assertEqualToResult
-  (fc (: ab (→ A B)) (fromNumber 2))
+  (fc &kb (: ab (→ A B)) (fromNumber 2))
   ((: ab (→ A B))
    (: (ModusPonens ab) (-> A B))
    (: ((ModusPonens ab) a) B)))
 !(assertEqualToResult
-  (fc (: a A) (fromNumber 3))
+  (fc &kb (: a A) (fromNumber 3))
   ((: a A)
-   (: ((ModusPonens ab) a) B)))
+   (: ((ModusPonens ab) a) B)
+   (: ((ModusPonens bc) ((ModusPonens ab) a)) C)))

--- a/metta/curried-chaining/curried-chainer.metta
+++ b/metta/curried-chaining/curried-chainer.metta
@@ -59,10 +59,10 @@
 ;; Curried Forward Chainer
 (: fc (-> $a Nat $a))
 ;; Base case.  Beware that the provided source is assumed to be true.
-(= (fc (: $proof $premise) $_) (: $proof $premise))
+(= (fc (: $prf $prms) $_) (: $prf $prms))
 ;; Recursive step
-(= (fc (: $prfarg $premise) (S $k))
-   (let (: $prfabs (-> $premise $ccln)) (bc (: $prfabs (-> $premise $ccln)) $k)
+(= (fc (: $prfarg $prms) (S $k))
+   (let (: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k)
      (fc (: ($prfabs $prfarg) $ccln) $k)))
 (= (fc (: $prfabs (-> $prms $ccln)) (S $k))
     (let (: $prfarg $prms) (bc (: $prfarg $prms) $k)

--- a/metta/proof-tree/README.md
+++ b/metta/proof-tree/README.md
@@ -1,0 +1,4 @@
+# Proof Tree Representation
+
+Code to generate the whole proof tree, proof as program tree annotated
+by its types on all branches.

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -349,10 +349,15 @@
           ($csc (append $cs $c)))
      (charsToString $csc)))
 
+;; len-str is added to MeTTa-Python stdlib instead
 ;; ;; Return the length of a string
 ;; (: len-str (-> String Number))
 ;; (= (len-str $s) (let $cs (stringToChars $s) (arity $cs)))
 
+;; Test len-str
+!(assertEqual (len-str "abc") 3)
+
+;; concat-str is added to MeTTa-Python stdlib instead
 ;; ;; Concatenate two strings
 ;; (: concat-str (-> String String String))
 ;; (= (concat-str $ls $rs)
@@ -360,6 +365,9 @@
 ;;           ($rcs (stringToChars $rs))
 ;;           ($lrcs (concat-atom $lcs $rcs)))
 ;;      (charsToString $lrcs)))
+
+;; Test concat-str
+!(assertEqual (concat-str "abc" "def") "abcdef")
 
 ;; Generate a String composed of a repeated String.
 (: repeat-str (-> String Number String))
@@ -369,15 +377,117 @@
        (let $r (repeat-str $s (- $n 1))
          (concat-str $s $r))))
 
-;; !(len-str "abc")
-;; !(concat-str "abc" "def")
-;; !(repeat-str "abc" 3)
+;; Test repeat-str
+!(assertEqual (repeat-str "abc" 3) "abcabcabc")
+
+;; Generate a string composed of a reapeated character
+;;
+;; For instance
+;;
+;; repeat-chr
+(: repeat-chr (-> Char Number String))
+(= (repeat-chr $c $n)
+   (repeat-str (charsToString ($c)) $n))
+
+;; Test repeat-chr
+!(assertEqual (repeat-chr ' ' 3) "   ")
+
+;; Given a tuple of strings, return the length of the string with
+;; maximum length.
+(: max-len-strs (-> Expression Number))
+(= (max-len-strs $strs)
+   (if (== $strs ())
+       0
+       (let $lens (len-str (superpose $strs))
+         (max-element (collapse $lens)))))
+
+;; Test max-len-strs
+!(assertEqual (max-len-strs ()) 0)
+!(assertEqual (max-len-strs ("abc" "a" "abcd")) 4)
+
+
+;; Pad the tailing part of a string with a given character to reach a
+;; given len.  If the string is longer than the target len, then the
+;; string is left untouched.
+;;
+;; For instance
+;;
+;; (pad-trail "abc" ' ' 5)
+;;
+;; outputs
+;;
+;; "abc  "
+(: pad-trail (-> String Char Number String))
+(= (pad-trail $s $c $n)
+   (let $len (len-str $s)
+     (if (< $len $n)
+         (concat-str $s (repeat-char $c (- $n $len)))
+         $s)))
+
+;; Test pad-trail
+!(assertEqual (pad-trail "abc" ' ' 5) "abc  ")
+
+;; Like pad-trail but applied to a tuple of strings
+(: pad-trails (-> Expression Char Number Expression))
+(= (pad-trails $strs $c $n)
+   (let* (($head (car-atom $strs))
+          ($tail (cdr-atom $strs))
+          ($padded-head (pad-trail $head $c $n))
+
+;; Given two tuples of lines, draw them side by side, as if they were
+;; both standing on the ground, with a given margin separating them.
+;;
+;; For instance
+;;
+;; (draw-side-by-side lhs rhs 1)
+;;
+;; where lhs represents
+;;
+;; "  / /"
+;; " /-/"
+;; "/ /"
+;;
+;; and rhs represents
+;;
+;; "  /"
+;; " /"
+;; "/"
+;;
+;; outputs
+;;
+;; "  / /   /"
+;; " /-/   /"
+;; "/ /   /"
+(: draw-side-by-side (-> Expression Expression Number Expression))
+(= (draw-side-by-side $lhs $rhs $margin)
+   (let* (($lhs-nlines (arity $lhs))
+          ($rhs-nlines (arity $rhs)))
+     (if (< $lhs-nlines $rhs-lines)
+         (let (($lhs-max-len (max-len-strs $lhs))
+               ($lhs-padded (pad-trails $lhs $lhs-max-len " "))
+         (repeat-str " " (pad-lines $lhs $lhs-max-len)
 
 ;; Given a fully annotated proof, return a string corresponding to an
 ;; ascii drawing of its proof in a Gentzen style.  For now, due to
 ;; MeTTa not supporting escaped characters, the ascii representation
 ;; is a tuple of lines, where each line is a String.  For instance the
 ;; string "abc\ndef" is represented by `("abs" "def")`.
+;;
+;; For instance
+;;
+;; (draw (: (ModusPonens (: bc (→ B C))
+;;                       (: (ModusPonens (: ab (→ A B))
+;;                                       (: a A)) B))
+;;           C))
+;;
+;; Outputs
+;;
+;; "             -------(ab)  -(a)"
+;; "             (→ A B)      A"
+;; "-------(bc)  --------------(ModusPonens)"
+;; "(→ B C)             B"
+;; "---------------------(ModusPonens)"
+;; "           C"
 (: draw (-> Expression Expression))
 (= (draw (: $prf $thrm))
    (if (is-expression $prf)
@@ -397,6 +507,7 @@
                   ($prfabs-par-str (concat-str (concat-str "(" $prfabs-str) ")"))
                   ($line-prfabs-str (concat-str $line-str $prfabs-par-str))
                   ($pad-len (ceil (/ (- $line-str-len $thrm-str-len)) 2))
+                  ;; NEXT: can we simplify using pad-trail?
                   ($space-pad (repeat-str " " $pad-len))
                   ($padded-thrm-str (concat-str $space-pad $thrm-str)))
              (concat-atom $prfargs-strs ($line-prfabs-str $padded-thrm-str))))
@@ -409,24 +520,36 @@
               ($line-prf-str (concat-str $line-str $prf-par-str)))
          ($line-prf-str $thrm-str))))
 
-;; Given a tuple of expressions of the form (: PROOF THEOREM), return
-;; an ascii drawing of these proofs in a Gentzen style side by side.
-;; Like for draw, a multi-line string is represented by a tuple of
-;; strings, one on each line.
-(: draw-tuple (-> Expression Expression))
-(= (draw-tuple $expr)
-   (if (== $expr ())
-       ()
-       (let* (($head (car-atom $expr))
-              ($tail (cdr-atom $expr))
-              ($drawn-head (draw $head))
-              ($drawn-tail (draw-tuple $tail))
-              ($drawn-head-nlines (arity $drawn-head))
-              ($drawn-tail-nlines (arity $drawn-tail)))
-         (if (< $drawn-head-nlines $drawn-tail-nlines)
-             ;; The tail is taller
-             (let* ((
-                    ($max-len-top-tail NEXT))))))))
+;; ;; Given a tuple of expressions of the form (: PROOF THEOREM), return
+;; ;; an ascii drawing of these proofs in a Gentzen style side by side.
+;; ;; Like for draw, a multi-line string is represented by a tuple of
+;; ;; strings, one on each line.
+;; ;;
+;; ;; For instance
+;; ;;
+;; ;; (draw-tuple ((: bc (→ B C))
+;; ;;              (: (ModusPonens (: ab (→ A B)) (: a A)) B))
+;; ;;
+;; ;; outputs
+;; ;;
+;; ;; "             -------(ab)  -(a)"
+;; ;; "             (→ A B)      A"
+;; ;; "-------(bc)  --------------(ModusPonens)"
+;; ;; "(→ B C)             B"
+;; (: draw-tuple (-> Expression Expression))
+;; (= (draw-tuple $expr)
+;;    (if (== $expr ())
+;;        ()
+;;        (let* (($head (car-atom $expr))
+;;               ($tail (cdr-atom $expr))
+;;               ($drawn-head (draw $head))
+;;               ($drawn-tail (draw-tuple $tail))
+;;               ($drawn-head-nlines (arity $drawn-head))
+;;               ($drawn-tail-nlines (arity $drawn-tail)))
+;;          (if (< $drawn-head-nlines $drawn-tail-nlines)
+;;              ;; The tail is taller
+;;              (let* (($head-max-len (max-element (len-str (superpose $drawn-head))
+;;                     ($max-len-top-tail NEXT))))))))
 
 ;; Test draw
 !(draw (: Refl (=== $x $x)))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -194,8 +194,7 @@
 ;;
 ;; (concat-atom (a b) (c d)) returns (a b c d)
 (: concat-atom (-> $a $a $a))
-(= (concat-atom $lhs $rhs) (foldr-tuple cons-atom $rhs $lhs))
-
+(= (concat-atom $lhs $rhs) (foldr cons-atom $rhs $lhs))
 
 ;; Test concat-atom
 !(assertEqual
@@ -205,52 +204,52 @@
   (concat-atom (a b) (c d))
   (a b c d))
 
-;; Split tuple into two tuple from a given position.  For instance
+;; SplitAt tuple into two tuple from a given position.  For instance
 ;;
-;; (split-tuple (a b c) 0) returns (() (a b c))
-;; (split-tuple (a b c) 1) returns ((a) (b c))
-;; (split-tuple (a b c) 2) returns ((a b) (c))
+;; (splitAt (a b c) 0) returns (() (a b c))
+;; (splitAt (a b c) 1) returns ((a) (b c))
+;; (splitAt (a b c) 2) returns ((a b) (c))
 ;;
 ;; If the position exceeds the arity of the tuple, then it behaves as
 ;; if the position was the arity.  For instance
 ;;
-;; (split-tuple (a b c) 4) returns ((a b c) ())
+;; (splitAt (a b c) 4) returns ((a b c) ())
 ;;
 ;; If $position is negative then it does not terminate.
-(: split-tuple (-> $a Number $a))
-(= (split-tuple $tuple $position)
+(: splitAt (-> $a Number $a))
+(= (splitAt $tuple $position)
    (if (== $position 0)
        (() $tuple)
        (if (== $tuple ())
            (() ())
            (let* (($head (car-atom $tuple))
                   ($tail (cdr-atom $tuple))
-                  (($split-head $split-tail) (split-tuple $tail (- $position 1))))
+                  (($split-head $split-tail) (splitAt $tail (- $position 1))))
              ((cons-atom $head $split-head) $split-tail)))))
 
-;; Test split-tuple
+;; Test splitAt
 !(assertEqual
-  (split-tuple (a b c) 0)
+  (splitAt (a b c) 0)
   (() (a b c)))
 !(assertEqual
-  (split-tuple (a b c) 1)
+  (splitAt (a b c) 1)
   ((a) (b c)))
 !(assertEqual
-  (split-tuple (a b c) 2)
+  (splitAt (a b c) 2)
   ((a b) (c)))
 !(assertEqual
-  (split-tuple (a b c) 3)
+  (splitAt (a b c) 3)
   ((a b c) ()))
 !(assertEqual
-  (split-tuple (a b c) 4)
+  (splitAt (a b c) 4)
   ((a b c) ()))
 
-;; Return the arity of an expression
-(= (acc $x $n) (+ 1 $n))
-(: arity (-> $a Number))
-(= (arity $expr) (foldr-tuple acc 0 $expr))
-;; TODO: re-enable when the interpreter is fixed
-;; (= (arity $expr) (foldr-tuple (λ $x $n (+ 1 $n)) 0 $expr))
+;; ;; Return the arity of an expression
+;; (= (acc $x $n) (+ 1 $n))
+;; (: arity (-> $a Number))
+;; (= (arity $expr) (foldr acc 0 $expr))
+;; ;; TODO: re-enable when the interpreter is fixed
+;; ;; (= (arity $expr) (foldr (λ $x $n (+ 1 $n)) 0 $expr))
 
 ;; Test arity
 !(assertEqual
@@ -266,7 +265,7 @@
 
 ;; Given a tuple of numbers, return the maximum, or 0 if empty.
 (: max-element (-> $a Number))
-(= (max-element $expr) (foldr-tuple max 0 $expr))
+(= (max-element $expr) (foldr max 0 $expr))
 
 ;; Test max-element
 !(assertEqual
@@ -309,7 +308,7 @@
 ;; Given a tuple of strings, return the length of the string with
 ;; maximum length.
 (: max-len-strs (-> $a Number))
-(= (max-len-strs $ss) (let $ls (map-tuple len-str $ss) (max-element $ls)))
+(= (max-len-strs $ss) (let $ls (map len-str $ss) (max-element $ls)))
 
 ;; Test max-len-strs
 !(assertEqual (max-len-strs ()) 0)
@@ -331,7 +330,7 @@
    (let $len (len-str $s)
      (if (< $len $n)
          (concat-str $s (repeat-str $c (- $n $len)))
-         $s)))
+         $s))))
 
 ;; Test pad-trail
 !(assertEqual
@@ -340,9 +339,12 @@
 
 ;; Like pad-trail but applied to a tuple of strings
 (: pad-trails (-> String Number $a $b))
-(= (pad-trails $c $n $ss) (map-tuple (((curry pad-trail) $c) $n) $ss)) ; NEXT
+(= (pad-trails $c $n $ss) (map (((curry3 pad-trail) $c) $n) $ss))
 
 ;; Test pad-trails
+!(assertEqual
+  (pad-trails " " 2 ("A"))
+  ("A "))
 !(assertEqual
   (pad-trails " " 5 ("A" "AB" "ABC"))
   ("A    " "AB   " "ABC  "))
@@ -554,6 +556,9 @@
   (flatten (((f a) b) ((g c) d)))
   (f a b (g c d)))
 !(assertEqual
+  (flatten (: ((plus (: 1 Number)) (: 2 Number)) Number))
+  (: (plus (: 1 Number) (: 2 Number)) Number))
+!(assertEqual
   (flatten (: ((ModusPonens (: bc (→ B C)))
                (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))
   (: (ModusPonens (: bc (→ B C)) (: (ModusPonens (: ab (→ A B)) (: a A)) B)) C))
@@ -577,23 +582,95 @@
 ;;
 ;; and rhs represents
 ;;
+;; "   /"
 ;; "  /"
 ;; " /"
 ;; "/"
 ;;
 ;; outputs
 ;;
+;; "         /"
 ;; "  / /   /"
 ;; " /-/   /"
 ;; "/ /   /"
-(: draw-side-by-side (-> Expression Expression Number Expression))
+;;
+;; TODO: replace type variables by Expression or some other proper
+;; types once Expression and quote has been decoupled.
+(: draw-side-by-side (-> $a $b Number $c))
 (= (draw-side-by-side $lhs $rhs $margin)
    (let* (($lhs-nlines (arity $lhs))
           ($rhs-nlines (arity $rhs)))
-     (if (< $lhs-nlines $rhs-lines)
-         (let (($lhs-max-len (max-len-strs $lhs))
-               ($lhs-padded (pad-trails $lhs $lhs-max-len " "))
-         (repeat-str " " (pad-lines $lhs $lhs-max-len)
+     (if (< $lhs-nlines $rhs-nlines)
+         (let* (($lhs-max-len (+ (max-len-strs $lhs) $margin))
+                ($lhs-padded (pad-trails " " $lhs-max-len $lhs))
+                ($lhs-blank-line (repeat-str " " $lhs-max-len))
+                ($diff-nlines (- $rhs-nlines $lhs-nlines))
+                ($lhs-blank-lines (repeat $lhs-blank-line $diff-nlines))
+                ($lhs-fully-padded (concat-atom $lhs-blank-lines $lhs-padded)))
+           (zipWith concat-str $lhs-fully-padded $rhs))
+         (let* (($diff-nlines (- $lhs-nlines $rhs-nlines))
+                (($lhs-top $lhs-bottom) (splitAt $lhs $diff-nlines))
+                ($lhs-bottom-max-len (max-len-strs $lhs-bottom))
+                ($lhs-bottom-padded (pad-trails " "
+                                                (+ $lhs-bottom-max-len $margin)
+                                                $lhs-bottom))
+                ($bottom (zipWith concat-str $lhs-bottom-padded $rhs)))
+           (concat-atom $lhs-top $bottom)))))
+
+Test draw-side-by-side
+!(assertEqual
+  (draw-side-by-side () () 1)
+  ())
+!(assertEqual
+  (draw-side-by-side ("1") () 1)
+  ("1"))
+!(assertEqual
+  (draw-side-by-side () ("2") 1)
+  (" 2"))
+!(assertEqual
+  (draw-side-by-side ("1") ("2") 1)
+  ("1 2"))
+!(assertEqual
+  (draw-side-by-side ("1") (" 2" "3") 1)
+  ("   2" "1 3"))
+!(assertEqual
+  (draw-side-by-side ("1" " 2") ("3") 1)
+  ("1" " 2 3"))
+!(assertEqual
+  (draw-side-by-side ("------(2)" "Number") () 2)
+  ("------(2)" "Number"))
+!(assertEqual
+  (draw-side-by-side ("------(1)" "Number") ("------(2)" "Number") 2)
+  ("------(1)  ------(2)" "Number     Number"))
+
+;; Given a tuple of expressions of the form (: PROOF THEOREM), return
+;; an ascii drawing of these proofs in a Gentzen style side by side.
+;; Like for draw, a multi-line string is represented by a tuple of
+;; strings, one on each line.
+;;
+;; For instance
+;;
+;; (draw-tuple ((: bc (→ B C))
+;;              (: (ModusPonens (: ab (→ A B)) (: a A)) B))
+;;
+;; outputs
+;;
+;; "             -------(ab)  -(a)"
+;; "             (→ A B)      A"
+;; "-------(bc)  --------------(ModusPonens)"
+;; "(→ B C)             B"
+;;
+;; TODO: replace type variables by Expression or some other proper
+;; types once Expression and quote has been decoupled.
+(: draw-tuple (-> $a $b))
+(= (draw-tuple $expr)
+   (if (== $expr ())
+       ()
+       (let* (($head (car-atom $expr))
+              ($tail (cdr-atom $expr))
+              ($drawn-head (draw $head))
+              ($drawn-tail (draw-tuple $tail)))
+         (draw-side-by-side $drawn-head $drawn-tail 2))))
 
 ;; Given a fully annotated proof, return a string corresponding to an
 ;; ascii drawing of its proof in a Gentzen style.  For now, due to
@@ -616,7 +693,10 @@
 ;; "(→ B C)             B"
 ;; "---------------------(ModusPonens)"
 ;; "           C"
-(: draw (-> Expression Expression))
+;;
+;; TODO: replace type variables by Expression or some other proper
+;; types once Expression and quote has been decoupled.
+(: draw (-> $a $b))
 (= (draw (: $prf $thrm))
    (if (is-expression $prf)
        ;; The proof is an expression
@@ -627,15 +707,23 @@
                   ($prfabs-str-len (len-str $prfabs))
                   ($prfargs (cdr-atom $prf))
                   ($prfargs-strs (draw-tuple $prfargs))
-                  ($prfargs-strs-len (max-element $prfargs-strs))
+                  ($prfargs-last-line (last $prfargs-strs))
+                  ($prfargs-last-line-len (len $prfargs-last-line))
+                  ;; NEXT: use $prfargs-last-line-len.  The last line
+                  ;; needs to be split into its heading spaces and
+                  ;; tail, then the size of the tail needs to be used
+                  ;; as input for for (repeat-str "-" ...), and then
+                  ;; the result needs to be stuck back to the same
+                  ;; heading spaces.
+                  ($prfargs-strs-lens (map len-str $prfargs-strs))
+                  ($prfargs-strs-max-len (max-element $prfargs-strs-lens))
                   ($thrm-str (repr $thrm))
                   ($thrm-str-len (len-str $thrm-str))
-                  ($line-str-len (max $prfargs-strs-len $thrm-str-len))
+                  ($line-str-len (max $prfargs-strs-max-len $thrm-str-len))
                   ($line-str (repeat-str "-" $line-str-len))
                   ($prfabs-par-str (concat-str (concat-str "(" $prfabs-str) ")"))
                   ($line-prfabs-str (concat-str $line-str $prfabs-par-str))
-                  ($pad-len (ceil (/ (- $line-str-len $thrm-str-len)) 2))
-                  ;; NEXT: can we simplify using pad-trail?
+                  ($pad-len (ceil (/ (- $line-str-len $thrm-str-len) 2)))
                   ($space-pad (repeat-str " " $pad-len))
                   ($padded-thrm-str (concat-str $space-pad $thrm-str)))
              (concat-atom $prfargs-strs ($line-prfabs-str $padded-thrm-str))))
@@ -648,36 +736,28 @@
               ($line-prf-str (concat-str $line-str $prf-par-str)))
          ($line-prf-str $thrm-str))))
 
-;; ;; Given a tuple of expressions of the form (: PROOF THEOREM), return
-;; ;; an ascii drawing of these proofs in a Gentzen style side by side.
-;; ;; Like for draw, a multi-line string is represented by a tuple of
-;; ;; strings, one on each line.
-;; ;;
-;; ;; For instance
-;; ;;
-;; ;; (draw-tuple ((: bc (→ B C))
-;; ;;              (: (ModusPonens (: ab (→ A B)) (: a A)) B))
-;; ;;
-;; ;; outputs
-;; ;;
-;; ;; "             -------(ab)  -(a)"
-;; ;; "             (→ A B)      A"
-;; ;; "-------(bc)  --------------(ModusPonens)"
-;; ;; "(→ B C)             B"
-;; (: draw-tuple (-> Expression Expression))
-;; (= (draw-tuple $expr)
-;;    (if (== $expr ())
-;;        ()
-;;        (let* (($head (car-atom $expr))
-;;               ($tail (cdr-atom $expr))
-;;               ($drawn-head (draw $head))
-;;               ($drawn-tail (draw-tuple $tail))
-;;               ($drawn-head-nlines (arity $drawn-head))
-;;               ($drawn-tail-nlines (arity $drawn-tail)))
-;;          (if (< $drawn-head-nlines $drawn-tail-nlines)
-;;              ;; The tail is taller
-;;              (let* (($head-max-len (max-element (len-str (superpose $drawn-head))
-;;                     ($max-len-top-tail NEXT))))))))
+;; Test draw-tuple
+!(assertEqual
+  (draw-tuple ())
+  ())
+!(assertEqual
+  (draw-tuple ((: 2 Number)))
+  ("------(2)" "Number"))
+!(assertEqual
+  (draw-tuple ((: 1 Number) (: 2 Number)))
+  ("------(1)  ------(2)" "Number     Number"))
 
 ;; Test draw
-!(draw (: Refl (=== $x $x)))
+!(assertEqual
+  (draw (: a A))
+  ("-(a)" "A"))
+!(assertEqual
+  (draw (: 2 Number))
+  ("------(2)" "Number"))
+!(assertEqual
+  (draw (: Refl (=== $x $x)))
+  ("-----------(Refl)" "(=== $x $x)"))
+;; NEXT: create assertEqual tests from the following
+;; !(draw (: (plus (: 1 Number) (: 2 Number)) Number))
+;; !(draw (: ((ModusPonens (: ab (→ A B))) (: a A)) B))
+;; !(draw (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -140,6 +140,10 @@
 ;; Flattener ;;
 ;;;;;;;;;;;;;;;
 
+;; Return True iff $term is an expression
+(: is-expression (-> Atom Bool))
+(= (is-expression $term) (== (get-metatype $term) Expression))
+
 ;; Concatenate two expressions
 ;;
 ;; for instance
@@ -162,6 +166,18 @@
   (concat-atom (a b) (c d))
   (a b c d))
 
+;; Like flatten but treat the given tuple as a list of expressions
+;; instead of an expression
+(: flatten-map (-> Expression Expression))
+(= (flatten-map $tuple)
+   (if (== $tuple ())
+       ()
+       (let* (($head (car-atom $tuple))
+              ($tail (cdr-atom $tuple))
+              ($flat-head (flatten $head))
+              ($flat-tail (flatten-map $tail)))
+         (cons-atom $flat-head $flat-tail))))
+
 ;; Flatten a curried expression.  For instance
 ;;
 ;; (flatten ((f a) b)) returns (f a b)
@@ -171,73 +187,75 @@
 ;; instance
 ;;
 ;; (flatten (-> T1 (-> T2 T3))) returns (-> T1 (-> T2 T3)), not (-> T1 T2 T3)
+(: flatten (-> Atom Atom))
 (= (flatten $term)
-   (case (get-metatype $term)
-     ((Symbol $term)
-      (Variable $term)
-      (Expression
+   (if (is-expression $term)
        (if (== $term ())
            ()
-           (let* (($hd (flatten (car-atom $term)))
-                  ($tl (flatten (cdr-atom $term))))
-             (case (get-metatype $hd)
-               ((Symbol (cons-atom $hd $tl))
-                (Variable (cons-atom $hd $tl))
-                (Expression
-                 (if (== $hd ())
-                     (cons-atom $hd $tl)
-                     (let* (($hd-hd (car-atom $hd))
-                            ($tl-hd (cdr-atom $hd))
-                            ($tl-hd-tl (concat-atom $tl-hd $tl)))
-                       (trace! ((term $term)
-                                (hd $hd)
-                                (tl $tl)
-                                (hd-hd $hd-hd)
-                                (tl-hd $tl-hd)
-                                (tl-hd-tl $tl-hd-tl)
-                                (result (cons-atom $hd-hd $tl-hd-tl)))
-                               (cons-atom $hd-hd $tl-hd-tl)))))))))))))
+           (let* (($head (car-atom $term))
+                  ($tail (cdr-atom $term))
+                  ($flat-head (flatten $head))
+                  ($flat-tail (flatten-map $tail)))
+             (if (is-expression $flat-head)
+                 (if (== $flat-head ())
+                     (cons-atom $flat-head $flat-tail)
+                     (let* (($hd-hd (car-atom $flat-head))
+                            ($tl-hd (cdr-atom $flat-head))
+                            ($tl-hd-tl (concat-atom $tl-hd $flat-tail)))
+                       (cons-atom $hd-hd $tl-hd-tl)))
+                 (cons-atom $flat-head $flat-tail))))
+       $term))
 
 ;; Test flatten
-;; !(assertEqual
-;;   (flatten a)
-;;   a)
-;; !(assertEqual
-;;   (flatten $x)
-;;   $x)
-;; !(assertEqual
-;;   (flatten ())
-;;   ())
-;; !(assertEqual
-;;   (flatten (()))
-;;   (()))
-;; !(assertEqual
-;;   (flatten (f a))
-;;   (f a))
+!(assertEqual
+  (flatten a)
+  a)
+!(assertEqual
+  (flatten $x)
+  $x)
+!(assertEqual
+  (flatten ())
+  ())
+!(assertEqual
+  (flatten (()))
+  (()))
+!(assertEqual
+  (flatten (f a))
+  (f a))
 !(assertEqual
   (flatten ((f a)))
-  ((f a)))                        ; NEXT: what should it be? (f a) or ((f a))?
-;; !(assertEqual
-;;   (flatten (() a))
-;;   (() a))
-;; !(assertEqual
-;;   (flatten ((f a) b))
-;;   (f a b))
-;; !(assertEqual
-;;   (flatten ((f a) ()))
-;;   (f a ()))
-;; !(assertEqual
-;;   (flatten ((f a b) c))
-;;   (f a b c))
-;; !(assertEqual
-;;   (flatten (((f a) b) c))
-;;   (f a b c))
-;; !(assertEqual
-;;   (flatten ((f a) (g c)))
-;;   (f a (g c))) ; NEXT
-;; !(assertEqual
-;;   (flatten (((f a) b) (g c)))
-;;   (f a b (g c))) ; NEXT
-;; !(assertEqual
-;;   (flatten (((f a) b) ((g c) d)))
-;;   (f a b (g c d))) ; NEXT
+  (f a))
+!(assertEqual
+  (flatten (() a))
+  (() a))
+!(assertEqual
+  (flatten ((f a) b))
+  (f a b))
+!(assertEqual
+  (flatten ((f a) ()))
+  (f a ()))
+!(assertEqual
+  (flatten ((f a b) c))
+  (f a b c))
+!(assertEqual
+  (flatten (((f a) b) c))
+  (f a b c))
+!(assertEqual
+  (flatten ((f a) b c))
+  (f a b c))
+!(assertEqual
+  (flatten ((f a) (g c)))
+  (f a (g c)))
+!(assertEqual
+  (flatten (((f a) b) (g c)))
+  (f a b (g c)))
+!(assertEqual
+  (flatten ((f a) (g c) (h d)))
+  (f a (g c) (h d)))
+!(assertEqual
+  (flatten (((f a) b) ((g c) d)))
+  (f a b (g c d)))
+!(assertEqual
+  (flatten (: ((ModusPonens (: bc (→ B C)))
+               (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))
+  (: (ModusPonens (: bc (→ B C)) (: (ModusPonens (: ab (→ A B)) (: a A)) B)) C))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -1,0 +1,96 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Backward and forward curried chainers generating fully annotated    ;;
+;; proof tree.                                                         ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;
+;; Nat ;;
+;;;;;;;;;
+
+;; Define Nat
+(: Nat Type)
+(: Z Nat)
+(: S (-> Nat Nat))
+
+;; Define <=
+(: <= (-> $a $a Bool))
+(= (<= $x $y) (or (< $x $y) (== $x $y)))
+
+;; Define cast functions between Nat and Number
+(: fromNumber (-> Number Nat))
+(= (fromNumber $n) (if (<= $n 0) Z (S (fromNumber (- $n 1)))))
+(: fromNat (-> Nat Number))
+(= (fromNat Z) 0)
+(= (fromNat (S $k)) (+ 1 (fromNat $k)))
+
+;;;;;;;;;;;;;;;;;;;;
+;; Knowledge base ;;
+;;;;;;;;;;;;;;;;;;;;
+
+!(bind! &kb (new-space))
+
+!(add-atom &kb (: a A))
+!(add-atom &kb (: ab (→ A B)))
+!(add-atom &kb (: bc (→ B C)))
+!(add-atom &kb (: ModusPonens
+                (-> (→ $p $q)
+                    (-> $p
+                        $q))))
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Backward chainer ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; Curried Backward Chainer
+(: bc (-> $a Nat $a))
+;; Base case
+(= (bc (: $prf $ccln) $_) (match &kb (: $prf $ccln) (: $prf $ccln)))
+;; Recursive step
+(= (bc (: ($prfabs (: $prfarg $prms)) $ccln) (S $k))
+   (let* (((: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k))
+          ((: $prfarg $prms) (bc (: $prfarg $prms) $k)))
+     (: ($prfabs (: $prfarg $prms)) $ccln)))
+
+;; Test curried backward chainer
+!(assertEqual
+  (bc (: $prf A) (fromNumber 0))
+  (: a A))
+!(assertEqual
+  (bc (: $prf B) (fromNumber 2))
+  (: ((ModusPonens (: ab (→ A B))) (: a A)) B))
+!(assertEqual
+  (bc (: $prf C) (fromNumber 3))
+  (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Forward chainer ;;
+;;;;;;;;;;;;;;;;;;;;;
+
+;; Curried Forward Chainer
+(: fc (-> $a Nat $a))
+;; Base case.  Beware that the provided source is assumed to be true.
+(= (fc (: $prf $prms) $_) (: $prf $prms))
+;; Recursive step
+(= (fc (: $prfarg $prms) (S $k))
+   (let (: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k)
+        (fc (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
+(= (fc (: $prfabs (-> $prms $ccln)) (S $k))
+   (let (: $prfarg $prms) (bc (: $prfarg $prms) $k)
+        (fc (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
+
+;; Test curried forward chainer
+!(assertEqualToResult
+  (fc (: ab (→ A B)) (fromNumber 1))
+  ((: ab (→ A B))
+   (: (ModusPonens (: ab (→ A B))) (-> A B))))
+!(assertEqualToResult
+  (fc (: ab (→ A B)) (fromNumber 2))
+  ((: ab (→ A B))
+   (: (ModusPonens (: ab (→ A B))) (-> A B))
+   (: ((ModusPonens (: ab (→ A B))) (: a A)) B)))
+!(assertEqualToResult
+  (fc (: a A) (fromNumber 3))
+  ((: a A)
+   (: ((ModusPonens (: ab (→ A B))) (: a A)) B)
+   (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C)))
+

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -55,40 +55,134 @@
 (= (ceil $n) (fromNat (fromNumber $n)))
 
 ;; Apply a given function to every element of a List
-(: map (-> (-> $a $b) (List $a) (List $b)))
-(= (map $f Nil) Nil)
-(= (map $f (Cons $h $t)) (Cons ($f $h) (map $f $t)))
+(: List.map (-> (-> $a $b) (List $a) (List $b)))
+(= (List.map $f Nil) Nil)
+(= (List.map $f (Cons $h $t)) (Cons ($f $h) (List.map $f $t)))
 
 ;; Apply a given function to every element of a tuple
-(: map-tuple (-> (-> $a $b) $c $d))
-(= (map-tuple $f $xs)
+(: map (-> (-> $a $b) $c $d))
+(= (map $f $xs)
    (if (== $xs ())
        ()
        (let* (($h (car-atom $xs))
               ($t (cdr-atom $xs))
               ($fh ($f $h))
-              ($ft (map-tuple $f $t)))
+              ($ft (map $f $t)))
          (cons-atom $fh $ft))))
 
-;; Test map-tuple
+;; Test map
 !(assertEqual
-  (map-tuple repr (1 2 3))
+  (map repr (1 2 3))
   ("1" "2" "3"))
 
+;; Return the location of the first element in a tuple meeting a
+;; certain condition.  If no such element exists return -1.
+(: findIf (-> (-> $a Bool) $b Number))
+(= (findIf $p $t) (findIf-rec $p $t 0))
+
+;; Like findIf but takes the location of the current tail tuple within
+;; the initial tuple.
+(: findIf-rec (-> (-> $a Bool) $b Number Number))
+(= (findIf-rec $p $t $l)
+   (if (== $t ())
+       -1
+       (let $hd (car-atom $t)
+         (if ($p $hd)
+             $l
+             (findIf-rec $p $t (+ 1 $l))))))
+
+;; Return the location of the first character in a string meeting a
+;; certain condition.  If no such character exists return -1.
+(: findIf-str (-> (-> Char Bool) String Number))
+(= (findIf-str $p $s) (findIf $p (stringToChars $s)))
+
+;; Return True iff the given character is a space character.
+(: isSpace (-> Char Bool))
+(= (isSpace $c)
+   (case $c
+     ((' ' True)
+      ('\t' True)
+      ($_ False))))
+
+;; Return True off the given character is not a space character.
+(: isNotSpace (-> Char Bool))
+(= (isNotSpace $c) (not (isSpace $c)))
+
+;; NEXT: test findIf-str
+
+;; Zip two tuples of same arity with a given function.
+;;
+;; TODO: replace type variables by Expression or some other proper
+;; types once Expression and quote has been decoupled.
+(: zipWith (-> (-> $a $b $c) $d $e $f))
+(= (zipWith $f $xs $ys)
+   (if (== $xs ())                      ; We assume (arity $xs) == (arity $ys)
+       ()
+       (let* (($xs-hd (car-atom $xs))
+              ($xs-tl (cdr-atom $xs))
+              ($ys-hd (car-atom $ys))
+              ($ys-tl (cdr-atom $ys))
+              ($head ($f $xs-hd $ys-hd))
+              ($tail (zipWith $f $xs-tl $ys-tl)))
+         (cons-atom $head $tail))))
+
+;; Test zipWith
+!(assertEqual
+  ()
+  ())
+!(assertEqual
+  (zipWith + (1 2 3) (4 5 6))
+  (5 7 9))
+
 ;; Fold a tuple from right to left
-(: foldr-tuple (-> (-> $a $b $b) $b $c $d))
-(= (foldr-tuple $f $i $xs)
+(: foldr (-> (-> $a $b $b) $b $c $d))
+(= (foldr $f $i $xs)
    (if (== $xs ())
        $i
        (let* (($h (car-atom $xs))
               ($t (cdr-atom $xs))
-              ($ft (foldr-tuple $f $i $t)))
+              ($ft (foldr $f $i $t)))
          ($f $h $ft))))
 
-;; Test foldr-tuple
+;; Test foldr
 !(assertEqual
-  (foldr-tuple + 0 (1 2 3))
+  (foldr + 0 (1 2 3))
   6)
+
+;; Generate a tuple by repeating an element n times
+(: repeat (-> $a Number $b))
+(= (repeat $x $n)
+   (if (== $n 0)
+       ()
+       (let $tail (repeat $x (- $n 1))
+         (cons-atom $x $tail))))
+
+;; Test repeat
+!(assertEqual
+  (repeat () 0)
+  ())
+!(assertEqual
+  (repeat () 3)
+  (() () ()))
+
+;; Return the last element of a tuple
+(: last (-> $a $b))
+(= (last $tuple)
+   (if (== $tuple ())
+       (empty)
+       (let* (($head (car-atom $tuple))
+              ($tail (cdr-atom $tuple)))
+         (if (== $tail ())
+             $head
+             (last $tail)))))
+
+;; Test last
+!(assertEqual
+  (last (A))
+  A)
+!(assertEqual
+  (last (A B C))
+  C)
 
 ;; Return True iff $term is an expression
 (: is-expression (-> Atom Bool))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -3,9 +3,31 @@
 ;; proof tree.                                                         ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;
-;; Nat ;;
-;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Common types and functions ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; ;; Unary lambda
+;; (: λ (-> Variable Atom Atom))
+;; (= ((λ $x $f) $y) (let $x $y $f))
+
+;; ;; Test unary λ
+;; !(assertEqual
+;;   ((λ $x (+ 1 $x)) 1)
+;;   2)
+
+;; ;; Binary lambda
+;; (: λ (-> Variable Variable Atom Atom Atom))
+;; (= ((λ $x $y $f) $z $w) (let* (($x $z) ($y $w)) $f))
+
+;; ;; Test binary λ
+;; !(assertEqual
+;;   ((λ $x $y (+ $x $y)) 1 2)
+;;   3)
+
+;; Curry a binary function
+(: curry (-> (-> $a $b $c) (-> $a (-> $b $c))))
+(= (((curry $f) $x) $y) ($f $x $y))
 
 ;; Define Nat
 (: Nat Type)
@@ -27,6 +49,205 @@
 ;; negative it returns 1.
 (: ceil (-> Number Number))
 (= (ceil $n) (fromNat (fromNumber $n)))
+
+;; Apply a given function to every element of a List
+(: map (-> (-> $a $b) (List $a) (List $b)))
+(= (map $f Nil) Nil)
+(= (map $f (Cons $h $t)) (Cons ($f $h) (map $f $t)))
+
+;; Apply a given function to every element of a tuple
+(: map-tuple (-> (-> $a $b) $c $d))
+(= (map-tuple $f $xs)
+   (if (== $xs ())
+       ()
+       (let* (($h (car-atom $xs))
+              ($t (cdr-atom $xs))
+              ($fh ($f $h))
+              ($ft (map-tuple $f $t)))
+         (cons-atom $fh $ft))))
+
+;; Test map-tuple
+!(assertEqual
+  (map-tuple repr (1 2 3))
+  ("1" "2" "3"))
+
+;; Fold a tuple from right to left
+(: foldr-tuple (-> (-> $a $b $b) $b $c $d))
+(= (foldr-tuple $f $i $xs)
+   (if (== $xs ())
+       $i
+       (let* (($h (car-atom $xs))
+              ($t (cdr-atom $xs))
+              ($ft (foldr-tuple $f $i $t)))
+         ($f $h $ft))))
+
+;; Test foldr-tuple
+!(assertEqual
+  (foldr-tuple + 0 (1 2 3))
+  6)
+
+;; Return True iff $term is an expression
+(: is-expression (-> Atom Bool))
+(= (is-expression $term) (== (get-metatype $term) Expression))
+
+;; Concatenate two tuples
+;;
+;; for instance
+;;
+;; (concat-atom (a b) (c d)) returns (a b c d)
+(: concat-atom (-> $a $a $a))
+(= (concat-atom $lhs $rhs) (foldr-tuple cons-atom $rhs $lhs))
+
+
+;; Test concat-atom
+!(assertEqual
+  (concat-atom (a b) ())
+  (a b))
+!(assertEqual
+  (concat-atom (a b) (c d))
+  (a b c d))
+
+;; Split tuple into two tuple from a given position.  For instance
+;;
+;; (split-tuple (a b c) 0) returns (() (a b c))
+;; (split-tuple (a b c) 1) returns ((a) (b c))
+;; (split-tuple (a b c) 2) returns ((a b) (c))
+;;
+;; If the position exceeds the arity of the tuple, then it behaves as
+;; if the position was the arity.  For instance
+;;
+;; (split-tuple (a b c) 4) returns ((a b c) ())
+;;
+;; If $position is negative then it does not terminate.
+(: split-tuple (-> $a Number $a))
+(= (split-tuple $tuple $position)
+   (if (== $position 0)
+       (() $tuple)
+       (if (== $tuple ())
+           (() ())
+           (let* (($head (car-atom $tuple))
+                  ($tail (cdr-atom $tuple))
+                  (($split-head $split-tail) (split-tuple $tail (- $position 1))))
+             ((cons-atom $head $split-head) $split-tail)))))
+
+;; Test split-tuple
+!(assertEqual
+  (split-tuple (a b c) 0)
+  (() (a b c)))
+!(assertEqual
+  (split-tuple (a b c) 1)
+  ((a) (b c)))
+!(assertEqual
+  (split-tuple (a b c) 2)
+  ((a b) (c)))
+!(assertEqual
+  (split-tuple (a b c) 3)
+  ((a b c) ()))
+!(assertEqual
+  (split-tuple (a b c) 4)
+  ((a b c) ()))
+
+;; Return the arity of an expression
+(= (acc $x $n) (+ 1 $n))
+(: arity (-> $a Number))
+(= (arity $expr) (foldr-tuple acc 0 $expr))
+;; TODO: re-enable when the interpreter is fixed
+;; (= (arity $expr) (foldr-tuple (λ $x $n (+ 1 $n)) 0 $expr))
+
+;; Test arity
+!(assertEqual
+  (arity ())
+  0)
+!(assertEqual
+  (arity (a b c))
+  3)
+
+;; Return the maximum of two number
+(: max (-> Number Number Number))
+(= (max $x $y) (if (< $x $y) $y $x))
+
+;; Given a tuple of numbers, return the maximum, or 0 if empty.
+(: max-element (-> $a Number))
+(= (max-element $expr) (foldr-tuple max 0 $expr))
+
+;; Test max-element
+!(assertEqual
+  (max-element (1 3 2))
+  3)
+
+;; Test len-str
+!(assertEqual
+  (len-str "abc")
+  3)
+
+;; Test concat-str
+!(assertEqual
+  (concat-str "abc" "def")
+  "abcdef")
+
+;; Generate a String composed of a repeated String.
+(: repeat-str (-> String Number String))
+(= (repeat-str $s $n)
+   (if (== $n 0)
+       ""
+       (let $r (repeat-str $s (- $n 1))
+         (concat-str $s $r))))
+
+;; Test repeat-str
+!(assertEqual
+  (repeat-str "abc" 3)
+  "abcabcabc")
+
+;; Test join-str
+!(assertEqual
+  (join-str ", " ("A" "B" "C"))
+  "A, B, C")
+
+;; Test split-str
+!(assertEqual
+  (split-str "A, B, C" ", ")
+  ("A" "B" "C"))
+
+;; Given a tuple of strings, return the length of the string with
+;; maximum length.
+(: max-len-strs (-> $a Number))
+(= (max-len-strs $ss) (let $ls (map-tuple len-str $ss) (max-element $ls)))
+
+;; Test max-len-strs
+!(assertEqual (max-len-strs ()) 0)
+!(assertEqual (max-len-strs ("abc" "a" "abcd")) 4)
+
+;; Pad the tailing part of a string with a given character to reach a
+;; given len.  If the string is longer than the target len, then the
+;; string is left untouched.
+;;
+;; For instance
+;;
+;; (pad-trail ' ' 5 "abc")
+;;
+;; outputs
+;;
+;; "abc  "
+(: pad-trail (-> String Number String String))
+(= (pad-trail $c $n $s)
+   (let $len (len-str $s)
+     (if (< $len $n)
+         (concat-str $s (repeat-str $c (- $n $len)))
+         $s)))
+
+;; Test pad-trail
+!(assertEqual
+  (pad-trail " " 5 "abc")
+  "abc  ")
+
+;; Like pad-trail but applied to a tuple of strings
+(: pad-trails (-> String Number $a $b))
+(= (pad-trails $c $n $ss) (map-tuple (((curry pad-trail) $c) $n) $ss)) ; NEXT
+
+;; Test pad-trails
+!(assertEqual
+  (pad-trails " " 5 ("A" "AB" "ABC"))
+  ("A    " "AB   " "ABC  "))
 
 ;;;;;;;;;;;;;;;;;;;;
 ;; Knowledge base ;;
@@ -145,35 +366,9 @@
 ;; Flattener ;;
 ;;;;;;;;;;;;;;;
 
-;; Return True iff $term is an expression
-(: is-expression (-> Atom Bool))
-(= (is-expression $term) (== (get-metatype $term) Expression))
-
-;; Concatenate two expressions
-;;
-;; for instance
-;;
-;; (concat-atom (a b) (c d)) returns (a b c d)
-(: concat-atom (-> Expression Expression Expression))
-(= (concat-atom $el $er)
-   (if (== $el ())
-       $er
-       (let* (($hd (car-atom $el))
-              ($tl (cdr-atom $el))
-              ($tler (concat-atom $tl $er)))
-         (cons-atom $hd $tler))))
-
-;; Test concat-atom
-!(assertEqual
-  (concat-atom (a b) ())
-  (a b))
-!(assertEqual
-  (concat-atom (a b) (c d))
-  (a b c d))
-
 ;; Like flatten but treat the given tuple as a list of expressions
 ;; instead of an expression
-(: flatten-map (-> Expression Expression))
+(: flatten-map (-> $a $a))
 (= (flatten-map $tuple)
    (if (== $tuple ())
        ()
@@ -268,171 +463,6 @@
 ;;;;;;;;;;;;
 ;; Drawer ;;
 ;;;;;;;;;;;;
-
-;; Return the arity of an expression
-(: arity (-> Expression Number))
-(= (arity $expr)
-   (if (== $expr ())
-       0
-       (let* (($head (car-atom $expr))
-              ($tail (cdr-atom $expr)))
-         (+ 1 (arity $tail)))))
-
-;; Split tuple into two tuple from a given position.  For instance
-;;
-;; (split-tuple (a b c) 0) returns (() (a b c))
-;; (split-tuple (a b c) 1) returns ((a) (b c))
-;; (split-tuple (a b c) 2) returns ((a b) (c))
-;;
-;; If the position exceeds the arity of the tuple, then it behaves as
-;; if the position was the arity.  For instance
-;;
-;; (split-tuple (a b c) 4) returns ((a b c) ())
-;;
-;; If $position is negative then it does not terminate.
-(: split-tuple (-> Expression Number Expression))
-(= (split-tuple $tuple $position)
-   (if (== $position 0)
-       (() $tuple)
-       (if (== $tuple ())
-           (() ())
-           (let* (($head (car-atom $tuple))
-                  ($tail (cdr-atom $tuple))
-                  (($split-head $split-tail) (split-tuple $tail (- $position 1))))
-             ((cons-atom $head $split-head) $split-tail)))))
-
-;; Test split-tuple
-!(assertEqual
-  (split-tuple (a b c) 0)
-  (() (a b c)))
-!(assertEqual
-  (split-tuple (a b c) 1)
-  ((a) (b c)))
-!(assertEqual
-  (split-tuple (a b c) 2)
-  ((a b) (c)))
-!(assertEqual
-  (split-tuple (a b c) 3)
-  ((a b c) ()))
-!(assertEqual
-  (split-tuple (a b c) 4)
-  ((a b c) ()))
-
-;; Return the maximum of two number
-(: max (-> Number Number Number))
-(= (max $x $y) (if (< $x $y) $y $x))
-
-;; Given a tuple of numbers, return the maximum, or 0 if empty.
-(: max-element (-> Expression Number))
-(= (max-element $tuple)
-   (if (== $tuple ())
-       0
-       (let* (($head (car-atom $tuple))
-              ($tail (cdr-atom $tuple))
-              ($max-tl (max-element $tail)))
-         (max $head $max-tl))))
-
-;; Append a term to an expression
-(: append (-> Expression Atom Expression))
-(= (append $expr $term)
-   (if (== $expr ())
-       ($term)
-       (let* (($head (car-atom $expr))
-              ($tail (cdr-atom $expr))
-              ($tail-term (append $tail $term)))
-         (cons-atom $head $tail-term))))
-
-;; Append a character to a string
-(: append-char (-> String Char String))
-(= (append-char $s $c)
-   (let* (($cs (stringToChars $s))
-          ($csc (append $cs $c)))
-     (charsToString $csc)))
-
-;; len-str is added to MeTTa-Python stdlib instead
-;; ;; Return the length of a string
-;; (: len-str (-> String Number))
-;; (= (len-str $s) (let $cs (stringToChars $s) (arity $cs)))
-
-;; Test len-str
-!(assertEqual (len-str "abc") 3)
-
-;; concat-str is added to MeTTa-Python stdlib instead
-;; ;; Concatenate two strings
-;; (: concat-str (-> String String String))
-;; (= (concat-str $ls $rs)
-;;    (let* (($lcs (stringToChars $ls))
-;;           ($rcs (stringToChars $rs))
-;;           ($lrcs (concat-atom $lcs $rcs)))
-;;      (charsToString $lrcs)))
-
-;; Test concat-str
-!(assertEqual (concat-str "abc" "def") "abcdef")
-
-;; Generate a String composed of a repeated String.
-(: repeat-str (-> String Number String))
-(= (repeat-str $s $n)
-   (if (== $n 0)
-       ""
-       (let $r (repeat-str $s (- $n 1))
-         (concat-str $s $r))))
-
-;; Test repeat-str
-!(assertEqual (repeat-str "abc" 3) "abcabcabc")
-
-;; Generate a string composed of a reapeated character
-;;
-;; For instance
-;;
-;; repeat-chr
-(: repeat-chr (-> Char Number String))
-(= (repeat-chr $c $n)
-   (repeat-str (charsToString ($c)) $n))
-
-;; Test repeat-chr
-!(assertEqual (repeat-chr ' ' 3) "   ")
-
-;; Given a tuple of strings, return the length of the string with
-;; maximum length.
-(: max-len-strs (-> Expression Number))
-(= (max-len-strs $strs)
-   (if (== $strs ())
-       0
-       (let $lens (len-str (superpose $strs))
-         (max-element (collapse $lens)))))
-
-;; Test max-len-strs
-!(assertEqual (max-len-strs ()) 0)
-!(assertEqual (max-len-strs ("abc" "a" "abcd")) 4)
-
-
-;; Pad the tailing part of a string with a given character to reach a
-;; given len.  If the string is longer than the target len, then the
-;; string is left untouched.
-;;
-;; For instance
-;;
-;; (pad-trail "abc" ' ' 5)
-;;
-;; outputs
-;;
-;; "abc  "
-(: pad-trail (-> String Char Number String))
-(= (pad-trail $s $c $n)
-   (let $len (len-str $s)
-     (if (< $len $n)
-         (concat-str $s (repeat-char $c (- $n $len)))
-         $s)))
-
-;; Test pad-trail
-!(assertEqual (pad-trail "abc" ' ' 5) "abc  ")
-
-;; Like pad-trail but applied to a tuple of strings
-(: pad-trails (-> Expression Char Number Expression))
-(= (pad-trails $strs $c $n)
-   (let* (($head (car-atom $strs))
-          ($tail (cdr-atom $strs))
-          ($padded-head (pad-trail $head $c $n))
 
 ;; Given two tuples of lines, draw them side by side, as if they were
 ;; both standing on the ground, with a given margin separating them.

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -26,8 +26,12 @@
 ;;   3)
 
 ;; Curry a binary function
-(: curry (-> (-> $a $b $c) (-> $a (-> $b $c))))
-(= (((curry $f) $x) $y) ($f $x $y))
+(: curry2 (-> (-> $a $b $c) (-> $a (-> $b $c))))
+(= (((curry2 $f) $x) $y) ($f $x $y))
+
+;; Curry a trinary function
+(: curry3 (-> (-> $a $b $c $d) (-> $a (-> $b (-> $c $d)))))
+(= ((((curry3 $f) $x) $y) $z) ($f $x $y $z))
 
 ;; Define Nat
 (: Nat Type)

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -23,6 +23,11 @@
 (= (fromNat Z) 0)
 (= (fromNat (S $k)) (+ 1 (fromNat $k)))
 
+;; Return the ceiling of a non negative number.  If the number is
+;; negative it returns 1.
+(: ceil (-> Number Number))
+(= (ceil $n) (fromNat (fromNumber $n)))
+
 ;;;;;;;;;;;;;;;;;;;;
 ;; Knowledge base ;;
 ;;;;;;;;;;;;;;;;;;;;
@@ -259,3 +264,169 @@
   (flatten (: ((ModusPonens (: bc (→ B C)))
                (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))
   (: (ModusPonens (: bc (→ B C)) (: (ModusPonens (: ab (→ A B)) (: a A)) B)) C))
+
+;;;;;;;;;;;;
+;; Drawer ;;
+;;;;;;;;;;;;
+
+;; Return the arity of an expression
+(: arity (-> Expression Number))
+(= (arity $expr)
+   (if (== $expr ())
+       0
+       (let* (($head (car-atom $expr))
+              ($tail (cdr-atom $expr)))
+         (+ 1 (arity $tail)))))
+
+;; Split tuple into two tuple from a given position.  For instance
+;;
+;; (split-tuple (a b c) 0) returns (() (a b c))
+;; (split-tuple (a b c) 1) returns ((a) (b c))
+;; (split-tuple (a b c) 2) returns ((a b) (c))
+;;
+;; If the position exceeds the arity of the tuple, then it behaves as
+;; if the position was the arity.  For instance
+;;
+;; (split-tuple (a b c) 4) returns ((a b c) ())
+;;
+;; If $position is negative then it does not terminate.
+(: split-tuple (-> Expression Number Expression))
+(= (split-tuple $tuple $position)
+   (if (== $position 0)
+       (() $tuple)
+       (if (== $tuple ())
+           (() ())
+           (let* (($head (car-atom $tuple))
+                  ($tail (cdr-atom $tuple))
+                  (($split-head $split-tail) (split-tuple $tail (- $position 1))))
+             ((cons-atom $head $split-head) $split-tail)))))
+
+;; Test split-tuple
+!(assertEqual
+  (split-tuple (a b c) 0)
+  (() (a b c)))
+!(assertEqual
+  (split-tuple (a b c) 1)
+  ((a) (b c)))
+!(assertEqual
+  (split-tuple (a b c) 2)
+  ((a b) (c)))
+!(assertEqual
+  (split-tuple (a b c) 3)
+  ((a b c) ()))
+!(assertEqual
+  (split-tuple (a b c) 4)
+  ((a b c) ()))
+
+;; Return the maximum of two number
+(: max (-> Number Number Number))
+(= (max $x $y) (if (< $x $y) $y $x))
+
+;; Given a tuple of numbers, return the maximum, or 0 if empty.
+(: max-element (-> Expression Number))
+(= (max-element $tuple)
+   (if (== $tuple ())
+       0
+       (let* (($head (car-atom $tuple))
+              ($tail (cdr-atom $tuple))
+              ($max-tl (max-element $tail)))
+         (max $head $max-tl))))
+
+;; Append a term to an expression
+(: append (-> Expression Atom Expression))
+(= (append $expr $term)
+   (if (== $expr ())
+       ($term)
+       (let* (($head (car-atom $expr))
+              ($tail (cdr-atom $expr))
+              ($tail-term (append $tail $term)))
+         (cons-atom $head $tail-term))))
+
+;; Append a character to a string
+(: append-char (-> String Char String))
+(= (append-char $s $c)
+   (let* (($cs (stringToChars $s))
+          ($csc (append $cs $c)))
+     (charsToString $csc)))
+
+;; ;; Return the length of a string
+;; (: len-str (-> String Number))
+;; (= (len-str $s) (let $cs (stringToChars $s) (arity $cs)))
+
+;; ;; Concatenate two strings
+;; (: concat-str (-> String String String))
+;; (= (concat-str $ls $rs)
+;;    (let* (($lcs (stringToChars $ls))
+;;           ($rcs (stringToChars $rs))
+;;           ($lrcs (concat-atom $lcs $rcs)))
+;;      (charsToString $lrcs)))
+
+;; Generate a String composed of a repeated String.
+(: repeat-str (-> String Number String))
+(= (repeat-str $s $n)
+   (if (== $n 0)
+       ""
+       (let $r (repeat-str $s (- $n 1))
+         (concat-str $s $r))))
+
+;; !(len-str "abc")
+;; !(concat-str "abc" "def")
+;; !(repeat-str "abc" 3)
+
+;; Given a fully annotated proof, return a string corresponding to an
+;; ascii drawing of its proof in a Gentzen style.  For now, due to
+;; MeTTa not supporting escaped characters, the ascii representation
+;; is a tuple of lines, where each line is a String.  For instance the
+;; string "abc\ndef" is represented by `("abs" "def")`.
+(: draw (-> Expression Expression))
+(= (draw (: $prf $thrm))
+   (if (is-expression $prf)
+       ;; The proof is an expression
+       (if (== $prf ())
+           ()
+           (let* (($prfabs (car-atom $prf))
+                  ($prfabs-str (repr $prfabs))
+                  ($prfabs-str-len (len-str $prfabs))
+                  ($prfargs (cdr-atom $prf))
+                  ($prfargs-strs (draw-tuple $prfargs))
+                  ($prfargs-strs-len (max-element $prfargs-strs))
+                  ($thrm-str (repr $thrm))
+                  ($thrm-str-len (len-str $thrm-str))
+                  ($line-str-len (max $prfargs-strs-len $thrm-str-len))
+                  ($line-str (repeat-str "-" $line-str-len))
+                  ($prfabs-par-str (concat-str (concat-str "(" $prfabs-str) ")"))
+                  ($line-prfabs-str (concat-str $line-str $prfabs-par-str))
+                  ($pad-len (ceil (/ (- $line-str-len $thrm-str-len)) 2))
+                  ($space-pad (repeat-str " " $pad-len))
+                  ($padded-thrm-str (concat-str $space-pad $thrm-str)))
+             (concat-atom $prfargs-strs ($line-prfabs-str $padded-thrm-str))))
+       ;; The proof is a symbol, or else
+       (let* (($prf-str (repr $prf))
+              ($prf-par-str (concat-str (concat-str "(" $prf-str) ")"))
+              ($thrm-str (repr $thrm))
+              ($thrm-str-len (len-str $thrm-str))
+              ($line-str (repeat-str "-" $thrm-str-len))
+              ($line-prf-str (concat-str $line-str $prf-par-str)))
+         ($line-prf-str $thrm-str))))
+
+;; Given a tuple of expressions of the form (: PROOF THEOREM), return
+;; an ascii drawing of these proofs in a Gentzen style side by side.
+;; Like for draw, a multi-line string is represented by a tuple of
+;; strings, one on each line.
+(: draw-tuple (-> Expression Expression))
+(= (draw-tuple $expr)
+   (if (== $expr ())
+       ()
+       (let* (($head (car-atom $expr))
+              ($tail (cdr-atom $expr))
+              ($drawn-head (draw $head))
+              ($drawn-tail (draw-tuple $tail))
+              ($drawn-head-nlines (arity $drawn-head))
+              ($drawn-tail-nlines (arity $drawn-tail)))
+         (if (< $drawn-head-nlines $drawn-tail-nlines)
+             ;; The tail is taller
+             (let* ((
+                    ($max-len-top-tail NEXT))))))))
+
+;; Test draw
+!(draw (: Refl (=== $x $x)))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -41,55 +41,97 @@
 ;; Backward chainer ;;
 ;;;;;;;;;;;;;;;;;;;;;;
 
-;; Curried Backward Chainer
-(: bc (-> $a Nat $a))
+;; Curried Backward Chainer with fully annotated proofs.  The
+;; arguments of the backward chainer are:
+;;
+;; * Knowledge base: pointer to a space containing axioms and rules in
+;;   the format (: <NAME> <RULE>).  Note that rules are explicitely
+;;   curried, meaning that a rule with two premises is represented by
+;;
+;;   (: <NAME> (-> <PREMISE1> (-> <PREMISE2> <CONCLUSION>)))
+;;
+;; * Query: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables that may be
+;;   filled by the backward chainer.
+;;
+;; * Maximum depth: maximum depth of the generated proof tree.
+;;
+;; A result is the query with its variables grounded, fully or
+;; partially.  If multiple results are possible, they are returned as
+;; a superposition.
+(: bc (-> $a                            ; Knowledge base space
+          $b                            ; Query
+          Nat                           ; Maximum depth
+          $b))                          ; Result
 ;; Base case
-(= (bc (: $prf $ccln) $_) (match &kb (: $prf $ccln) (: $prf $ccln)))
+(= (bc $kb (: $prf $ccln) $_) (match $kb (: $prf $ccln) (: $prf $ccln)))
 ;; Recursive step
-(= (bc (: ($prfabs (: $prfarg $prms)) $ccln) (S $k))
-   (let* (((: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k))
-          ((: $prfarg $prms) (bc (: $prfarg $prms) $k)))
+(= (bc $kb (: ($prfabs (: $prfarg $prms)) $ccln) (S $k))
+   (let* (((: $prfabs (-> $prms $ccln)) (bc $kb (: $prfabs (-> $prms $ccln)) $k))
+          ((: $prfarg $prms) (bc $kb (: $prfarg $prms) $k)))
      (: ($prfabs (: $prfarg $prms)) $ccln)))
 
 ;; Test curried backward chainer
 !(assertEqual
-  (bc (: $prf A) (fromNumber 0))
+  (bc &kb (: $prf A) (fromNumber 0))
   (: a A))
 !(assertEqual
-  (bc (: $prf B) (fromNumber 2))
+  (bc &kb (: $prf B) (fromNumber 2))
   (: ((ModusPonens (: ab (→ A B))) (: a A)) B))
 !(assertEqual
-  (bc (: $prf C) (fromNumber 3))
+  (bc &kb (: $prf C) (fromNumber 3))
   (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Forward chainer ;;
 ;;;;;;;;;;;;;;;;;;;;;
 
-;; Curried Forward Chainer
-(: fc (-> $a Nat $a))
-;; Base case.  Beware that the provided source is assumed to be true.
-(= (fc (: $prf $prms) $_) (: $prf $prms))
+;; Curried Forward Chainer with fully annotated proofs.  The arguments
+;; of the forward chainer are:
+;;
+;; * Knowledge base: pointer to a space containing axioms and rules in
+;;   the format (: <NAME> <RULE>).  Note that rules are explicitely
+;;   curried, meaning that a rule with two premises is represented by
+;;
+;;   (: <NAME> (-> <PREMISE1> (-> <PREMISE2> <CONCLUSION>)))
+;;
+;; * Source: a metta term of the form (: <PROOF> <THEOREM>) where
+;;   <PROOF> and <THEOREM> may contain free variables.  Beware that
+;;   the source is assumed to be true.  That is especially important
+;;   to consider when introducing free variables, because these free
+;;   variables will be treated as if they are univerally quantified.
+;;
+;; * Maximum depth: maximum depth of the generated proof tree.
+;;
+;; A result is a conclusion that can be reached from the source.  If
+;; multiple results are possible, they are returned as a
+;; superposition.
+(: fc (-> $a                            ; Knowledge base space
+          $b                            ; Source
+          Nat                           ; Maximum depth
+          $b))                          ; Conclusion
+;; Base case
+(= (fc $kb (: $prf $prms) $_) (: $prf $prms))
 ;; Recursive step
-(= (fc (: $prfarg $prms) (S $k))
-   (let (: $prfabs (-> $prms $ccln)) (bc (: $prfabs (-> $prms $ccln)) $k)
-        (fc (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
-(= (fc (: $prfabs (-> $prms $ccln)) (S $k))
-   (let (: $prfarg $prms) (bc (: $prfarg $prms) $k)
-        (fc (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
+(= (fc $kb (: $prfarg $prms) (S $k))
+   (let (: $prfabs (-> $prms $ccln)) (bc $kb (: $prfabs (-> $prms $ccln)) $k)
+        (fc $kb (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
+(= (fc $kb (: $prfabs (-> $prms $ccln)) (S $k))
+   (let (: $prfarg $prms) (bc $kb (: $prfarg $prms) $k)
+        (fc $kb (: ($prfabs (: $prfarg $prms)) $ccln) $k)))
 
 ;; Test curried forward chainer
 !(assertEqualToResult
-  (fc (: ab (→ A B)) (fromNumber 1))
+  (fc &kb (: ab (→ A B)) (fromNumber 1))
   ((: ab (→ A B))
    (: (ModusPonens (: ab (→ A B))) (-> A B))))
 !(assertEqualToResult
-  (fc (: ab (→ A B)) (fromNumber 2))
+  (fc &kb (: ab (→ A B)) (fromNumber 2))
   ((: ab (→ A B))
    (: (ModusPonens (: ab (→ A B))) (-> A B))
    (: ((ModusPonens (: ab (→ A B))) (: a A)) B)))
 !(assertEqualToResult
-  (fc (: a A) (fromNumber 3))
+  (fc &kb (: a A) (fromNumber 3))
   ((: a A)
    (: ((ModusPonens (: ab (→ A B))) (: a A)) B)
    (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C)))

--- a/metta/proof-tree/proof-tree.metta
+++ b/metta/proof-tree/proof-tree.metta
@@ -136,3 +136,108 @@
    (: ((ModusPonens (: ab (→ A B))) (: a A)) B)
    (: ((ModusPonens (: bc (→ B C))) (: ((ModusPonens (: ab (→ A B))) (: a A)) B)) C)))
 
+;;;;;;;;;;;;;;;
+;; Flattener ;;
+;;;;;;;;;;;;;;;
+
+;; Concatenate two expressions
+;;
+;; for instance
+;;
+;; (concat-atom (a b) (c d)) returns (a b c d)
+(: concat-atom (-> Expression Expression Expression))
+(= (concat-atom $el $er)
+   (if (== $el ())
+       $er
+       (let* (($hd (car-atom $el))
+              ($tl (cdr-atom $el))
+              ($tler (concat-atom $tl $er)))
+         (cons-atom $hd $tler))))
+
+;; Test concat-atom
+!(assertEqual
+  (concat-atom (a b) ())
+  (a b))
+!(assertEqual
+  (concat-atom (a b) (c d))
+  (a b c d))
+
+;; Flatten a curried expression.  For instance
+;;
+;; (flatten ((f a) b)) returns (f a b)
+;;
+;; Note that it only flattens left-associative application.  Therefore
+;; it will not work on the arrow type as it is right-associative.  For
+;; instance
+;;
+;; (flatten (-> T1 (-> T2 T3))) returns (-> T1 (-> T2 T3)), not (-> T1 T2 T3)
+(= (flatten $term)
+   (case (get-metatype $term)
+     ((Symbol $term)
+      (Variable $term)
+      (Expression
+       (if (== $term ())
+           ()
+           (let* (($hd (flatten (car-atom $term)))
+                  ($tl (flatten (cdr-atom $term))))
+             (case (get-metatype $hd)
+               ((Symbol (cons-atom $hd $tl))
+                (Variable (cons-atom $hd $tl))
+                (Expression
+                 (if (== $hd ())
+                     (cons-atom $hd $tl)
+                     (let* (($hd-hd (car-atom $hd))
+                            ($tl-hd (cdr-atom $hd))
+                            ($tl-hd-tl (concat-atom $tl-hd $tl)))
+                       (trace! ((term $term)
+                                (hd $hd)
+                                (tl $tl)
+                                (hd-hd $hd-hd)
+                                (tl-hd $tl-hd)
+                                (tl-hd-tl $tl-hd-tl)
+                                (result (cons-atom $hd-hd $tl-hd-tl)))
+                               (cons-atom $hd-hd $tl-hd-tl)))))))))))))
+
+;; Test flatten
+;; !(assertEqual
+;;   (flatten a)
+;;   a)
+;; !(assertEqual
+;;   (flatten $x)
+;;   $x)
+;; !(assertEqual
+;;   (flatten ())
+;;   ())
+;; !(assertEqual
+;;   (flatten (()))
+;;   (()))
+;; !(assertEqual
+;;   (flatten (f a))
+;;   (f a))
+!(assertEqual
+  (flatten ((f a)))
+  ((f a)))                        ; NEXT: what should it be? (f a) or ((f a))?
+;; !(assertEqual
+;;   (flatten (() a))
+;;   (() a))
+;; !(assertEqual
+;;   (flatten ((f a) b))
+;;   (f a b))
+;; !(assertEqual
+;;   (flatten ((f a) ()))
+;;   (f a ()))
+;; !(assertEqual
+;;   (flatten ((f a b) c))
+;;   (f a b c))
+;; !(assertEqual
+;;   (flatten (((f a) b) c))
+;;   (f a b c))
+;; !(assertEqual
+;;   (flatten ((f a) (g c)))
+;;   (f a (g c))) ; NEXT
+;; !(assertEqual
+;;   (flatten (((f a) b) (g c)))
+;;   (f a b (g c))) ; NEXT
+;; !(assertEqual
+;;   (flatten (((f a) b) ((g c) d)))
+;;   (f a b (g c d))) ; NEXT


### PR DESCRIPTION
The full annotation is complete but drawing the tree isn't due to some bug in handling space character in MeTTa.