### PR TITLE
fix imports according  to changes with modules in hyperon

### DIFF
--- a/metta/common/EqualityTypeTest.metta
+++ b/metta/common/EqualityTypeTest.metta
@@ -1,5 +1,5 @@
 ;; Import ===
-!(import! &self EqualityType.metta)
+!(import! &self metta:common:EqualityType)
 
 ;; Define various subterms
 (: TTrue True)

--- a/metta/common/In.metta
+++ b/metta/common/In.metta
@@ -1,8 +1,8 @@
 ;; Definitions of ∈ and ∉ types including axioms and rules
 
 ;; Import modules
-!(import! &self Num.metta)
-!(import! &self OrderedSet.metta)
+!(import! &self metta:common:Num)
+!(import! &self metta:common:OrderedSet)
 
 ;; Type representing whether an element is or not in a set
 (: ∈ (-> $a (OrderedSet $a) Type))

--- a/metta/common/InTest.metta
+++ b/metta/common/InTest.metta
@@ -1,9 +1,9 @@
 ;; Test ∉
 
 ;; Import modules
-!(import! &self In.metta)
-!(import! &self Num.metta)
-!(import! &self ../synthesis/Synthesize.metta)
+!(import! &self metta:common:In)
+!(import! &self metta:common:Num)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Define knowledge and rule bases to reason about ∉.  This requires
 ;; reasoning about order as well (Natural for now).

--- a/metta/common/ListTest.metta
+++ b/metta/common/ListTest.metta
@@ -1,5 +1,5 @@
 ;; Import List
-!(import! &self List.metta)
+!(import! &self metta:common:List)
 
 ;; Test insert
 !("============ Test insert ============")

--- a/metta/common/MaybeTest.metta
+++ b/metta/common/MaybeTest.metta
@@ -1,4 +1,4 @@
-!(import! &self Maybe.metta)
+!(import! &self metta:common:Maybe)
 
 ;; Test Maybe
 !(Maybe< (Just 10) (Just 20))

--- a/metta/common/NumTest.metta
+++ b/metta/common/NumTest.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self Num.metta)
-!(import! &self ../synthesis/Synthesize.metta)
+!(import! &self metta:common:Num)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Test elementary functions
 !(assertEqual (fromNumber 1) (S Z))

--- a/metta/common/OrderedSet.metta
+++ b/metta/common/OrderedSet.metta
@@ -1,5 +1,5 @@
 ;; Import modules
-!(import! &self Num.metta)
+!(import! &self metta:common:Num)
 
 ;; Definition of a set data structure.  Under the hood it is a sorted
 ;; list without duplicates, thus called OrderedSet.  For now its

--- a/metta/common/OrderedSetTest.metta
+++ b/metta/common/OrderedSetTest.metta
@@ -1,5 +1,5 @@
 ;; Import OrderedSet
-!(import! &self OrderedSet.metta)
+!(import! &self metta:common:OrderedSet)
 
 ;; Test elem
 !(assertEqual (elem 1 ∅) False)

--- a/metta/common/formula/DeductionFormula.metta
+++ b/metta/common/formula/DeductionFormula.metta
@@ -1,8 +1,8 @@
 ;; Formula and other functions used for the deduction rule
 
 ;; Import modules
-!(import! &self ../truthvalue/TruthValue.metta)
-!(import! &self ../Num.metta)
+!(import! &self metta:common:truthvalue:TruthValue)
+!(import! &self metta:common:Num)
 
 ; Consistency Conditions
 (: smallest-intersection-probability (-> Number Number Number))

--- a/metta/common/formula/DeductionFormulaTest.metta
+++ b/metta/common/formula/DeductionFormulaTest.metta
@@ -1,4 +1,4 @@
-!(import! &self DeductionFormula.metta)
+!(import! &self metta:common:formula:DeductionFormula)
 
 ;; Test
 !(assertEqualToResult (max 3 4) (4))

--- a/metta/common/formula/ImplicationDirectIntroductionFormula.metta
+++ b/metta/common/formula/ImplicationDirectIntroductionFormula.metta
@@ -1,7 +1,7 @@
 ;; Formula for the inductive Implication Direct Introduction rule.
 
 ;; Import modules
-!(import! &self ../truthvalue/TruthValue.metta)
+!(import! &self metta:common:truthvalue:TruthValue)
 
 ;; Alternate implication direct introduction formula assuming Boolean
 ;; evidence.  Base case, meaning there is only one piece of evidence.

--- a/metta/common/formula/ModusPonensFormula.metta
+++ b/metta/common/formula/ModusPonensFormula.metta
@@ -1,8 +1,8 @@
 ;; Formula for the modus ponens rule
 
 ;; Import modules
-!(import! &self ../truthvalue/TruthValue.metta)
-!(import! &self ../Num.metta)
+!(import! &self metta:common:truthvalue:TruthValue)
+!(import! &self metta:common:Num)
 
 (= (modus-ponens-formula (STV $As $Ac)
                          (STV $ABs $ABc))

--- a/metta/common/truthvalue/EvidentialTruthValue.metta
+++ b/metta/common/truthvalue/EvidentialTruthValue.metta
@@ -1,8 +1,8 @@
 ;; Evidential truth value type. Represent a truth value alongside its
 ;; evidence.
 
-!(import! &self TruthValue.metta)
-!(import! &self ../OrderedSet.metta)
+!(import! &self metta:common:truthvalue:TruthValue)
+!(import! &self metta:common:OrderedSet)
 
 ;;;;;;;;;;
 ;; Type ;;

--- a/metta/common/truthvalue/EvidentialTruthValueTest.metta
+++ b/metta/common/truthvalue/EvidentialTruthValueTest.metta
@@ -1,5 +1,5 @@
 ;; Import TruthValue
-!(import! &self EvidentialTruthValue.metta)
+!(import! &self metta:common:truthvalue:EvidentialTruthValue)
 
 !(mode (ETV (Singleton 42) (STV 0.1 0.2)))        ; 0.1
 !(mean (ETV (Singleton 42) (STV 0.1 0.9)))        ; 0.14

--- a/metta/common/truthvalue/TemporalTruthValue.metta
+++ b/metta/common/truthvalue/TemporalTruthValue.metta
@@ -5,7 +5,7 @@
 ;;
 ;; Time is discrete for now.
 
-!(import! &self EvidentialTruthValue.metta)
+!(import! &self metta:common:truthvalue:EvidentialTruthValue)
 
 ;;;;;;;;;;;
 ;; Types ;;

--- a/metta/common/truthvalue/TruthValue.metta
+++ b/metta/common/truthvalue/TruthValue.metta
@@ -1,7 +1,7 @@
 ;; Truth value type definition
 
 ;; Import modules
-!(import! &self ../Num.metta)
+!(import! &self  metta:common:Num)
 
 ;;;;;;;;;;
 ;; Type ;;

--- a/metta/common/truthvalue/TruthValueTest.metta
+++ b/metta/common/truthvalue/TruthValueTest.metta
@@ -1,5 +1,5 @@
 ;; Import TruthValue
-!(import! &self TruthValue.metta)
+!(import! &self metta:common:truthvalue:TruthValue)
 
 !(assertEqual (count->confidence 1) 0.5)
 !(assertEqual (count->confidence 10) 0.9090909090909091)

--- a/metta/hol/ListTest.metta
+++ b/metta/hol/ListTest.metta
@@ -1,5 +1,5 @@
 ;; Import synthesizer
-!(import! ../synthesis/Synthesize.metta)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Define List data type and constructors
 (: List (-> $a Type))

--- a/metta/hol/NatSimpleTest.metta
+++ b/metta/hol/NatSimpleTest.metta
@@ -3,7 +3,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Import synthesizer (Nat is already defined in it)
-!(import! &self ../synthesis/Synthesize.metta)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/hol/NatTest.metta
+++ b/metta/hol/NatTest.metta
@@ -9,7 +9,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Import synthesizer (Nat is already defined in it)
-!(import! &self ../synthesis/Synthesize.metta)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/pln/dependent-types/DeductionDTL.metta
+++ b/metta/pln/dependent-types/DeductionDTL.metta
@@ -14,8 +14,8 @@
 ;; TV represents the resulting truth value of the conclusion.
 
 ;; Import modules
-!(import! &self ../../common/truthvalue/MeasEq.metta)
-!(import! &self ../../common/formula/DeductionFormula.metta)
+!(import! &self metta:common:truthvalue:MeasEq)
+!(import! &self metta:common:formula:DeductionFormula)
 
 ;; Define deduction rule
 (: deduction-rule (-> Atom))

--- a/metta/pln/dependent-types/DeductionDTLTest.metta
+++ b/metta/pln/dependent-types/DeductionDTLTest.metta
@@ -5,9 +5,9 @@
 ;; (: = (-> $t $t Type))
 
 ;; Import modules
-!(import! &self DeductionDTL.metta)
-!(import! &self ../../synthesis/Synthesize.metta)
-!(import! &self ../../common/Record.metta)
+!(import! &self metta:pln:dependent-types:DeductionDTL)
+!(import! &self metta:synthesis:Synthesize)
+!(import! &self metta:common:Record)
 
 ;; Knowledge base
 (: Predicate Type)

--- a/metta/pln/dependent-types/DeductionImplicationDirectIntroductionDTLTest.metta
+++ b/metta/pln/dependent-types/DeductionImplicationDirectIntroductionDTLTest.metta
@@ -1,9 +1,9 @@
 ;; Test DeductionDTL and ImplicationDirectionIntroductionDTL rules
 
 ;; Import the rules
-!(import! &self ImplicationDirectIntroductionDTL.metta)
-!(import! &self DeductionDTL.metta)
-!(import! &self ../../synthesis/Synthesize.metta)
+!(import! &self metta:pln:dependent-types:ImplicationDirectIntroductionDTL)
+!(import! &self metta:pln:dependent-types:DeductionDTL)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/pln/dependent-types/ImplicationDirectIntroductionDTL.metta
+++ b/metta/pln/dependent-types/ImplicationDirectIntroductionDTL.metta
@@ -42,8 +42,8 @@
 ;; function.
 
 ;; Import modules
-!(import! &self ../../common/truthvalue/EvidentialTruthValue.metta)
-!(import! &self ../../common/formula/ImplicationDirectIntroductionFormula.metta)
+!(import! &self metta:common:truthvalue:EvidentialTruthValue)
+!(import! &self metta:common:formula:ImplicationDirectIntroductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/dependent-types/ImplicationDirectIntroductionDTLTest.metta
+++ b/metta/pln/dependent-types/ImplicationDirectIntroductionDTLTest.metta
@@ -1,8 +1,8 @@
 ;; Test Implication Direct Introduction DTL Rule
 
 ;; Import modules
-!(import! &self ImplicationDirectIntroductionDTL.metta)
-!(import! &self ../../synthesis/Synthesize.metta)
+!(import! &self metta:pln:dependent-types:ImplicationDirectIntroductionDTL)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/pln/dependent-types/ModusPonensDTL.metta
+++ b/metta/pln/dependent-types/ModusPonensDTL.metta
@@ -28,8 +28,8 @@
 
 
 ;; Import modules
-!(import! &self ../../common/truthvalue/MeasEq.metta)
-!(import! &self ../../common/formula/ModusPonensFormula.metta)
+!(import! &self metta:common:truthvalue:MeasEq)
+!(import! &self metta:common:formula:ModusPonensFormula)
 
 ;; Define modus ponens rule
 (: modus-ponens-rule (-> Atom))

--- a/metta/pln/dependent-types/ModusPonensDTLTest.metta
+++ b/metta/pln/dependent-types/ModusPonensDTLTest.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self ModusPonensDTL.metta)
-!(import! &self ../../synthesis/Synthesize.metta)
+!(import! &self metta:pln:dependent-types:ModusPonensDTL)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Puzzle:
 ;; The cow is big.

--- a/metta/pln/entail/DeductionEntail.metta
+++ b/metta/pln/entail/DeductionEntail.metta
@@ -14,7 +14,7 @@
 ;; TV represents the resulting truth value of the conclusion.
 
 ;; Import formula functions
-!(import! &self ../common/DeductionFormula.metta)
+!(import! &self metta:common:formula:DeductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/entail/DeductionEntailTest.metta
+++ b/metta/pln/entail/DeductionEntailTest.metta
@@ -1,5 +1,5 @@
 ;; Test Deduction Entail Rule
-!(import! &self DeductionEntail.metta)
+!(import! &self metta:pln:entail:DeductionEntail)
 
 (= (P) (≞ P (STV 1 0.1)))
 (= (Q) (≞ Q (STV 1 0.1)))

--- a/metta/pln/entail/ImplicationDirectIntroductionEntail.metta
+++ b/metta/pln/entail/ImplicationDirectIntroductionEntail.metta
@@ -15,9 +15,9 @@
 ;; represents the resulting truth value of the conclusion.
 
 ;; Import modules
-!(import! &self ../common/OrderedSet.metta)
-!(import! &self ../common/EvidentialTruthValue.metta)
-!(import! &self ../common/ImplicationDirectIntroductionFormula.metta)
+!(import! &self metta:common:OrderedSet)
+!(import! &self metta:common:truthvalue:EvidentialTruthValue)
+!(import! &self metta:common:formula:ImplicationDirectIntroductionFormula)
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;
 ;;;;;;;;;;;;;;;;;;;;;

--- a/metta/pln/entail/ImplicationDirectIntroductionEntailTest.metta
+++ b/metta/pln/entail/ImplicationDirectIntroductionEntailTest.metta
@@ -1,5 +1,5 @@
 ;; Test Implication Direct Introduction Entail Rule
-!(import! &self ImplicationDirectIntroductionEntail.metta)
+!(import! &self  metta:pln:entail:ImplicationDirectIntroductionEntail)
 
 ;; Test formula
 !("========== Test formula ==========")

--- a/metta/pln/equal/DeductionEqual.metta
+++ b/metta/pln/equal/DeductionEqual.metta
@@ -14,7 +14,7 @@
 ;; TV represents the resulting truth value of the conclusion.
 
 ;; Import formula functions
-!(import! &self ../common/DeductionFormula.metta)
+!(import! &self metta:common:formula:DeductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/equal/DeductionEqualTest.metta
+++ b/metta/pln/equal/DeductionEqualTest.metta
@@ -1,5 +1,5 @@
 ;; Test Deduction equality Rule
-!(import! &self DeductionEqual.metta)
+!(import! &self  metta:pln:equal:DeductionEqual)
 
 ;; Test 1:
 !(, (≞ P (STV 1 0.1))

--- a/metta/pln/equal/ImplicationDirectIntroductionEqual.metta
+++ b/metta/pln/equal/ImplicationDirectIntroductionEqual.metta
@@ -15,9 +15,9 @@
 ;; represents the resulting truth value of the conclusion.
 
 ;; Import modules
-!(import! &self ../common/OrderedSet.metta)
-!(import! &self ../common/EvidentialTruthValue.metta)
-!(import! &self ../common/ImplicationDirectIntroductionFormula.metta)
+!(import! &self  metta:common:OrderedSet)
+!(import! &self  metta:common:truthvalue:EvidentialTruthValue)
+!(import! &self metta:common:formula:ImplicationDirectIntroductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/equal/ImplicationDirectIntroductionEqualTest.metta
+++ b/metta/pln/equal/ImplicationDirectIntroductionEqualTest.metta
@@ -1,4 +1,4 @@
 ;; Test Implication Direct Introduction Equal Rule
-!(import! &self ImplicationDirectIntroductionEqual.metta)
+!(import! &self metta:common:formula:ImplicationDirectIntroductionEqual.metta)
 
 ;; TODO

--- a/metta/pln/match/DeductionImplicationDirectIntroductionMatchTest.metta
+++ b/metta/pln/match/DeductionImplicationDirectIntroductionMatchTest.metta
@@ -1,7 +1,7 @@
 ; DeductionMatch and ImplicationDirectionIntroductionMatch
 
-!(import! &self ImplicationDirectIntroductionMatch.metta)
-!(import! &self DeductionMatch.metta)
+!(import! &self metta:pln:match:ImplicationDirectIntroductionMatch)
+!(import! &self metta:pln:match:DeductionMatch)
 
 ; Use IDI rule to infer P->Q based on the following,
 (≞ (P 42) (Bl True))

--- a/metta/pln/match/DeductionMatch.metta
+++ b/metta/pln/match/DeductionMatch.metta
@@ -14,7 +14,7 @@
 ;; TV represents the resulting truth value of the conclusion.
 
 ;; Import formula functions
-!(import! &self ../common/DeductionFormula.metta)
+!(import! &self metta:common:formula:DeductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/match/DeductionMatchTest.metta
+++ b/metta/pln/match/DeductionMatchTest.metta
@@ -1,5 +1,5 @@
 ;; Test Deduction match Rule
-!(import! &self DeductionMatch.metta)
+!(import! &self metta:pln:match:DeductionMatch)
 
 (≞ P (STV 1 0.1))
 (≞ Q (STV 1 0.1))

--- a/metta/pln/match/ImplicationDirectIntroductionMatch.metta
+++ b/metta/pln/match/ImplicationDirectIntroductionMatch.metta
@@ -15,9 +15,9 @@
 ;; represents the resulting truth value of the conclusion.
 
 ;; Import modules
-!(import! &self ../common/OrderedSet.metta)
-!(import! &self ../common/EvidentialTruthValue.metta)
-!(import! &self ../common/ImplicationDirectIntroductionFormula.metta)
+!(import! &self metta:common:OrderedSet)
+!(import! &self metta:common:truthvalue:EvidentialTruthValue)
+!(import! &self metta:common:formula:ImplicationDirectIntroductionFormula)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Rule Definition ;;

--- a/metta/pln/match/ImplicationDirectIntroductionMatchTest.metta
+++ b/metta/pln/match/ImplicationDirectIntroductionMatchTest.metta
@@ -1,5 +1,5 @@
 ;; Test Implication Direct Introduction Match Rule
-!(import! &self ImplicationDirectIntroductionMatch.metta)
+!(import! &self metta:pln:match:ImplicationDirectIntroductionMatch)
 
 (≞ (P 42) (Bl True))
 (≞ (Q 42) (Bl False))

--- a/metta/subtyping/subtyping-test.metta
+++ b/metta/subtyping/subtyping-test.metta
@@ -1,10 +1,10 @@
 ;; Test subtyping
 
 ;; Import synthesizer
-!(import! &self ../synthesis/Synthesize.metta)
+!(import! &self metta:synthesis:Synthesize)
 
 ;; Import rule base
-!(import! &rb rule-base.metta)
+!(import! &rb metta:subtyping:rule-base)
 
 ;; Define knowledge base for that test
 (: kb (-> Atom))

--- a/metta/synthesis/Synthesize.metta
+++ b/metta/synthesis/Synthesize.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self ../common/Num.metta)
-;; !(import! &self Unify.metta)
+!(import! &self metta:common:Num)
+;; !(import! &self metta:synthesis:Unify)
 
 ;; Enumerate all programs up to a given depth that are consistent with
 ;; the query, using the given axiom non-deterministic functions and rules.

--- a/metta/synthesis/SynthesizeTest.metta
+++ b/metta/synthesis/SynthesizeTest.metta
@@ -1,8 +1,8 @@
 ;; Setting up a simple knowledge base and rule base for demoing reasoning in MeTTa.
 
 ;; Import modules
-!(import! &self Synthesize.metta)
-!(import! &self ../common/Record.metta)
+!(import! &self metta:synthesis:Synthesize)
+!(import! &self metta:common:Record)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/synthesis/UnifyTest.metta
+++ b/metta/synthesis/UnifyTest.metta
@@ -1,5 +1,5 @@
 ;; Import module
-!(import! &self Unify.metta)
+!(import! &self  metta:synthesis:Unify)
 
 ;; Test unify.
 ;; Should output (Link A B)

--- a/metta/synthesis/experiments/synthesize-via-case-test.metta
+++ b/metta/synthesis/experiments/synthesize-via-case-test.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self synthesize-via-case.metta)
-!(import! &self ../../common/Record.metta)
+!(import! &self metta:synthesis:experiments:synthesize-via-case)
+!(import! &self metta:common:Record)
 
 ;; Test program synthesizer
 !(record syn ((: $term $type) Z))                  ; (: f (-> Number String)), (: g (-> String Bool)), (: h (-> Bool Number))

--- a/metta/synthesis/experiments/synthesize-via-case.metta
+++ b/metta/synthesis/experiments/synthesize-via-case.metta
@@ -1,5 +1,5 @@
 ;; Import modules
-!(import! &self ../../common/Num.metta)
+!(import! &self metta:common:Num)
 
 ;; Define set of rules
 (= (rules) (: . (-> (-> $b $c) (-> $a $b) (-> $a $c))))

--- a/metta/synthesis/experiments/synthesize-via-let-test.metta
+++ b/metta/synthesis/experiments/synthesize-via-let-test.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self synthesize-via-let.metta)
-!(import! &self ../../common/Record.metta)
+!(import! &self metta:synthesis:experiments:synthesize-via-let)
+!(import! &self metta:common:Record)
 
 ;; Test program synthesizer
 !(record syn ((: $term $type) Z))                  ; (: f (-> Number String)), (: g (-> String Bool)), (: h (-> Bool Number))

--- a/metta/synthesis/experiments/synthesize-via-let.metta
+++ b/metta/synthesis/experiments/synthesize-via-let.metta
@@ -1,5 +1,5 @@
 ;; Import modules
-!(import! &self ../../common/Num.metta)
+!(import! &self metta:common:Num)
 
 ;; Define set of rules
 (= (rules) (: . (-> (-> $b $c) (-> $a $b) (-> $a $c))))

--- a/metta/synthesis/experiments/synthesize-via-type-checking.metta
+++ b/metta/synthesis/experiments/synthesize-via-type-checking.metta
@@ -1,5 +1,5 @@
 ;; Import modules
-!(import! &self ../../common/Num.metta)
+!(import! &self metta:common:Num)
 
 ;; ;; Type definitions checker
 ;; !(pragma! type-check auto)

--- a/metta/synthesis/experiments/synthesize-via-unify-test.metta
+++ b/metta/synthesis/experiments/synthesize-via-unify-test.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self synthesize-via-unify.metta)
-!(import! &self ../../common/Record.metta)
+!(import! &self metta:synthesis:experiments:synthesize-via-unify)
+!(import! &self metta:common:Record)
 
 ;; Knowledge base
 (: kb (-> Atom))

--- a/metta/synthesis/experiments/synthesize-via-unify.metta
+++ b/metta/synthesis/experiments/synthesize-via-unify.metta
@@ -1,6 +1,6 @@
 ;; Import modules
-!(import! &self ../../common/Num.metta)
-!(import! &self ../Unify.metta)
+!(import! &self metta:common:Num)
+!(import! &self metta:synthesis:Unify)
 
 ;; Enumerate all programs up to a given depth that are consistent with
 ;; the query, using the given axioms and rules.


### PR DESCRIPTION
I was asked by team to run all the files and the flowing problems were found:
InTest.metta works very long
synthesize-via-unify-test.metta finished with sigkill

Tests fail:
calculi-converter.metta
inf-ctl-month-bc-cont-xp.metta
inf-ctl-month-bc-xp.metta
proof-tree.metta